### PR TITLE
feat: Introduce @tanstack/react-query

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@auth0/auth0-react": "^2.1.1",
     "@react-leaflet/core": "^2.1.0",
+    "@tanstack/react-query": "^4.29.15",
     "atob": "^2.1.2",
     "classnames": "^2.3.2",
     "express": "^4.18.2",

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,4 +1,3 @@
-import React, { useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { Link } from "react-router-dom";
 import {
@@ -10,22 +9,11 @@ import {
   Image,
   Label,
 } from "semantic-ui-react";
-import { useAuth0 } from "@auth0/auth0-react";
 import { Loading } from "./common/widgets/widgets";
-import { getAbout } from "../api";
+import { useData } from "../api";
 
 const About = () => {
-  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const [data, setData] = useState(null);
-  useEffect(() => {
-    const update = async () => {
-      const accessToken = isAuthenticated
-        ? await getAccessTokenSilently()
-        : null;
-      getAbout(accessToken).then((data) => setData(data));
-    };
-    update();
-  }, [isAuthenticated]);
+  const { data } = useData(`/about`);
 
   if (!data) {
     return <Loading />;
@@ -262,7 +250,8 @@ const About = () => {
                     <Label.Detail>
                       <a
                         href="https://web.archive.org/web/20160205060357/http://www.buldreinfo.com/"
-                        target="_blank" rel="noreferrer"
+                        target="_blank"
+                        rel="noreferrer"
                       >
                         source: archive.net
                       </a>
@@ -295,7 +284,8 @@ const About = () => {
                       <Label.Detail>
                         <a
                           href="https://web.archive.org/web/20110923004804/http://www.buldreinfo.com/"
-                          target="_blank" rel="noreferrer"
+                          target="_blank"
+                          rel="noreferrer"
                         >
                           source: archive.net
                         </a>
@@ -313,7 +303,8 @@ const About = () => {
                       <Label.Detail>
                         <a
                           href="https://web.archive.org/web/20071104020049/http://www.buldreinfo.com/"
-                          target="_blank" rel="noreferrer"
+                          target="_blank"
+                          rel="noreferrer"
                         >
                           source: archive.net
                         </a>
@@ -355,7 +346,8 @@ const About = () => {
                     <Label.Detail>
                       <a
                         href="https://web.archive.org/web/20050308114436/http://www.brv.no/gammelt/buldring/oversikt.htm"
-                        target="_blank" rel="noreferrer"
+                        target="_blank"
+                        rel="noreferrer"
                       >
                         source: archive.net
                       </a>

--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useRef } from "react";
 import { Helmet } from "react-helmet";
 import { Link, useNavigate } from "react-router-dom";
 import {
@@ -12,17 +12,15 @@ import {
 import Leaflet from "./common/leaflet/leaflet";
 import ChartGradeDistribution from "./common/chart-grade-distribution/chart-grade-distribution";
 import { Loading, LockSymbol } from "./common/widgets/widgets";
-import { useAuth0 } from "@auth0/auth0-react";
-import { getBrowse } from "../api";
+import { useData } from "../api";
 import { Remarkable } from "remarkable";
 import { linkify } from "remarkable/linkify";
 
 const Browse = () => {
-  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const [data, setData] = useState(null);
+  const { data } = useData(`/browse`);
   const [flyToId, setFlyToId] = useState(null);
   const [showForDevelopers, setShowForDevelopers] = useState(false);
-  const leafletRef = useRef();
+  const leafletRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
   const md = new Remarkable({ breaks: true }).use(linkify);
   // open links in new windows
@@ -36,19 +34,6 @@ const Browse = () => {
       );
     };
   })();
-  useEffect(() => {
-    if (!isLoading) {
-      const update = async () => {
-        const accessToken = isAuthenticated
-          ? await getAccessTokenSilently()
-          : null;
-        getBrowse(accessToken).then((data) =>
-          setData({ ...data, accessToken })
-        );
-      };
-      update();
-    }
-  }, [isLoading, isAuthenticated]);
 
   if (!data) {
     return <Loading />;
@@ -80,13 +65,13 @@ const Browse = () => {
             >
               <Icon name="external" />
             </Button>
-            <a href={"/area/" + a.id}>
+            <Link to={"/area/" + a.id}>
               <b>{a.name}</b>{" "}
               <LockSymbol
                 lockedAdmin={a.lockedAdmin}
                 lockedSuperadmin={a.lockedSuperadmin}
               />
-            </a>
+            </Link>
             <i>{`(${a.numSectors} sectors, ${a.numProblems} ${typeDescription})`}</i>
             <br />
             {a.numProblems > 0 && (

--- a/src/components/ContentGraph.tsx
+++ b/src/components/ContentGraph.tsx
@@ -1,29 +1,16 @@
-import React, { useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { Header, Segment, Icon } from "semantic-ui-react";
 import { Loading } from "./common/widgets/widgets";
-import { useAuth0 } from "@auth0/auth0-react";
-import { getCg } from "../api";
+import { useData } from "../api";
 import ChartGradeDistribution from "./common/chart-grade-distribution/chart-grade-distribution";
 
 const Toc = () => {
-  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const [data, setData] = useState(null);
-  useEffect(() => {
-    if (!isLoading) {
-      const update = async () => {
-        const accessToken = isAuthenticated
-          ? await getAccessTokenSilently()
-          : null;
-        getCg(accessToken).then((data) => setData({ ...data, accessToken }));
-      };
-      update();
-    }
-  }, [isLoading, isAuthenticated]);
+  const { data } = useData(`/cg`);
 
   if (!data) {
     return <Loading />;
   }
+
   return (
     <>
       <Helmet>

--- a/src/components/Dangerous.tsx
+++ b/src/components/Dangerous.tsx
@@ -1,25 +1,12 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import { Helmet } from "react-helmet";
 import { LockSymbol, Loading } from "./common/widgets/widgets";
 import { Segment, Icon, List, Header } from "semantic-ui-react";
-import { useAuth0 } from "@auth0/auth0-react";
-import { getDangerous } from "../api";
+import { useData } from "../api";
 
 const Dangerous = () => {
-  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const [data, setData] = useState(null);
+  const { data } = useData(`/dangerous`);
   const areaRefs = useRef({});
-  useEffect(() => {
-    if (!isLoading) {
-      const update = async () => {
-        const accessToken = isAuthenticated
-          ? await getAccessTokenSilently()
-          : null;
-        getDangerous(accessToken).then((data) => setData(data));
-      };
-      update();
-    }
-  }, [isLoading, isAuthenticated]);
 
   if (!data) {
     return <Loading />;

--- a/src/components/Frontpage.tsx
+++ b/src/components/Frontpage.tsx
@@ -1,4 +1,3 @@
-import React, { useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import {
   Label,
@@ -11,25 +10,11 @@ import {
   Placeholder,
 } from "semantic-ui-react";
 import { Link } from "react-router-dom";
-import { useAuth0 } from "@auth0/auth0-react";
-import { getFrontpage, getImageUrl, numberWithCommas } from "../api";
+import { getImageUrl, numberWithCommas, useData } from "../api";
 import Activity from "./common/activity/activity";
 
 const Frontpage = () => {
-  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const [frontpage, setFrontpage] = useState(null);
-
-  useEffect(() => {
-    if (!isLoading) {
-      const update = async () => {
-        const accessToken = isAuthenticated
-          ? await getAccessTokenSilently()
-          : null;
-        getFrontpage(accessToken).then((res) => setFrontpage(res));
-      };
-      update();
-    }
-  }, [isLoading, isAuthenticated]);
+  const { data: frontpage } = useData(`/frontpage`);
 
   return (
     <>

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useRef } from "react";
 import { Helmet } from "react-helmet";
 import {
   Header,
@@ -9,26 +9,14 @@ import {
   ButtonGroup,
 } from "semantic-ui-react";
 import { Loading, LockSymbol, Stars } from "./common/widgets/widgets";
-import { useAuth0 } from "@auth0/auth0-react";
-import { getToc, getTocXlsx } from "../api";
+import { getTocXlsx, useAccessToken, useData } from "../api";
 import { saveAs } from "file-saver";
 
 const Toc = () => {
-  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const [data, setData] = useState(null);
+  const accessToken = useAccessToken();
+  const { data } = useData(`/toc`);
   const [isSaving, setIsSaving] = useState(false);
   const areaRefs = useRef({});
-  useEffect(() => {
-    if (!isLoading) {
-      const update = async () => {
-        const accessToken = isAuthenticated
-          ? await getAccessTokenSilently()
-          : null;
-        getToc(accessToken).then((data) => setData({ ...data, accessToken }));
-      };
-      update();
-    }
-  }, [isLoading, isAuthenticated]);
 
   if (!data) {
     return <Loading />;
@@ -60,7 +48,7 @@ const Toc = () => {
             onClick={() => {
               setIsSaving(true);
               let filename = "toc.xlsx";
-              getTocXlsx(data.accessToken)
+              getTocXlsx(accessToken)
                 .then((response) => {
                   filename = response.headers
                     .get("content-disposition")

--- a/src/components/Trash.tsx
+++ b/src/components/Trash.tsx
@@ -1,35 +1,17 @@
-import React, { useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { Loading } from "./common/widgets/widgets";
-import { getImageUrl } from "../api";
-import { getTrash, putTrash } from "../api";
+import { getImageUrl, useData } from "../api";
+import { putTrash } from "../api";
 import { Segment, Icon, Header, List, Button, Image } from "semantic-ui-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
 import { InsufficientPrivileges } from "./common/widgets/widgets";
 
 const Trash = () => {
-  const {
-    isLoading,
-    isAuthenticated,
-    getAccessTokenSilently,
-    loginWithRedirect,
-  } = useAuth0();
-  const [data, setData] = useState(null);
+  const { isLoading, isAuthenticated, loginWithRedirect } = useAuth0();
+  const { data } = useData(`/trash`);
   const location = useLocation();
   const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!isLoading) {
-      const update = async () => {
-        const accessToken = isAuthenticated
-          ? await getAccessTokenSilently()
-          : null;
-        getTrash(accessToken).then((data) => setData({ ...data, accessToken }));
-      };
-      update();
-    }
-  }, [isLoading, isAuthenticated]);
 
   if (isLoading || (isAuthenticated && !data)) {
     return <Loading />;

--- a/src/components/WebcamMap.tsx
+++ b/src/components/WebcamMap.tsx
@@ -1,21 +1,19 @@
-import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import Leaflet from "./common/leaflet/leaflet";
 import { Segment, Header, Icon } from "semantic-ui-react";
 import { Loading } from "./common/widgets/widgets";
-import { getCameras } from "../api";
+import { useData } from "../api";
 
 const WebcamMap = () => {
-  const [data, setData] = useState(null);
+  const { data } = useData(`/cameras`);
   const { json } = useParams();
   const navigate = useNavigate();
-  useEffect(() => {
-    getCameras().then((data) => setData(data));
-  }, []);
+
   if (!data) {
     return <Loading />;
   }
+
   const markers = data.cameras
     .filter((c) => c.lat != 0 && c.lng != 0)
     .map((c) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { Auth0Provider } from "@auth0/auth0-react";
 import { ErrorBoundary } from "react-error-boundary";
 import App from "./App";
 import "./buldreinfo.css";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 function ErrorFallback({ error, resetErrorBoundary }) {
   const userAgent = navigator.userAgent;
@@ -69,17 +70,27 @@ export const Auth0ProviderWithNavigate = ({ children }) => {
   );
 };
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 60 * 24, // 24 hours
+    },
+  },
+});
+
 const Index = () => (
-  <BrowserRouter>
-    <ErrorBoundary
-      FallbackComponent={ErrorFallback}
-      onReset={() => window.location.reload()}
-    >
-      <Auth0ProviderWithNavigate>
-        <App />
-      </Auth0ProviderWithNavigate>
-    </ErrorBoundary>
-  </BrowserRouter>
+  <QueryClientProvider client={queryClient}>
+    <BrowserRouter>
+      <ErrorBoundary
+        FallbackComponent={ErrorFallback}
+        onReset={() => window.location.reload()}
+      >
+        <Auth0ProviderWithNavigate>
+          <App />
+        </Auth0ProviderWithNavigate>
+      </ErrorBoundary>
+    </BrowserRouter>
+  </QueryClientProvider>
 );
 
 const root = createRoot(document.getElementById("app"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,19 @@
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1" "^0.70.2"
     "@swagger-api/apidom-parser-adapter-yaml-1-2" "^0.70.1"
 
+"@tanstack/query-core@4.29.15":
+  version "4.29.15"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.29.15.tgz#6f8721341dbece517326a8e402d29ea3365538a8"
+  integrity sha512-Recc1d5rjHesKhzlH3Aw66v+vQxtB9OHEXP/vxgEcEJ0DwEpfe3EQ4id20vuBJHY2XRjfgWGmUs6ZgK6PSsTXA==
+
+"@tanstack/react-query@^4.29.15":
+  version "4.29.15"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.29.15.tgz#83598e46964185199c59757e6b9c63c15eff81c1"
+  integrity sha512-1zDkv95ljuJ623hhbYU8YIprPW2x6774kh3IQNEuZav62+S+Zr26uUOrE2zGRp9I1uO5Liw/0uYB3dWXQP5+3Q==
+  dependencies:
+    "@tanstack/query-core" "4.29.15"
+    use-sync-external-store "^1.2.0"
+
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
@@ -8345,7 +8358,7 @@ use-isomorphic-layout-effect@^1.1.2:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
   integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
-use-sync-external-store@^1.0.0:
+use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
Using the app is a little painful today - every time you navigate to a new page, the data must be fetched anew. This works _okay_ on a device on Wi-Fi, but this can be really irritating when out at the crags. Out there, cell service is much less reliable and can leave one stuck looking at a loading screen.

Instead, introduce `@tanstack/react-query`, which is a modern hook-based state management solution for data liveliness. This allows us to show stale data and refresh it in the background. In the future, it would allow us to plug in proper offline support, too.

This PR is a **first pass** over some of the pages. Specifically, only the ones which make `GET` requests without parameters. The rest shouldn't be a problem to follow the same pattern, but I didn't want to rewrite the entire app in one PR, and this seemed like a good stopping point.