### PR TITLE
feat: Improve data fetching for Top & Todo

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -809,6 +809,16 @@ export function getTicks(
     });
 }
 
+export function useTodo({
+  idArea,
+  idSector,
+}: {
+  idArea: number;
+  idSector: number;
+}) {
+  return useData(`/todo?idArea=${idArea}&idSector=${idSector}`);
+}
+
 export function getTodo(
   accessToken: string | null,
   idArea: number,
@@ -826,28 +836,14 @@ export function getTodo(
     });
 }
 
-export function getTop(
-  idArea: number,
-  idSector: number
-): Promise<
-  {
-    rank: number;
-    picture: string;
-    userId: string | number;
-    name: string;
-    percentage: string | number;
-  }[]
-> {
-  return makeAuthenticatedRequest(
-    null,
-    `/top?idArea=${idArea}&idSector=${idSector}`,
-    null
-  )
-    .then((data) => data.json())
-    .catch((error) => {
-      console.warn(error);
-      return null;
-    });
+export function useTop({
+  idArea,
+  idSector,
+}: {
+  idArea: number;
+  idSector: number;
+}) {
+  return useData(`/top?idArea=${idArea}&idSector=${idSector}`);
 }
 
 export function getTocXlsx(accessToken: string | null): Promise<any> {

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -252,7 +252,7 @@ const Area = () => {
       menuItem: { key: "todo", icon: "bookmark" },
       render: () => (
         <Tab.Pane>
-          <Todo accessToken={accessToken} idArea={data.id} idSector={0} />
+          <Todo idArea={data.id} idSector={0} />
         </Tab.Pane>
       ),
     });

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -299,7 +299,7 @@ const Sector = () => {
       menuItem: { key: "todo", icon: "bookmark" },
       render: () => (
         <Tab.Pane>
-          <Todo accessToken={data.accessToken} idArea={0} idSector={data.id} />
+          <Todo idArea={0} idSector={data.id} />
         </Tab.Pane>
       ),
     });

--- a/src/components/common/todo/todo.tsx
+++ b/src/components/common/todo/todo.tsx
@@ -1,24 +1,20 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import { Loading, LockSymbol } from "../widgets/widgets";
 import { Header, Icon, List } from "semantic-ui-react";
-import { getTodo } from "../../../api";
+import { useTodo } from "../../../api";
 
-const Todo = ({ accessToken, idArea, idSector }) => {
-  const [data, setData] = useState<any>(null);
-  useEffect(() => {
-    if (data != null) {
-      setData(null);
-    }
-    getTodo(accessToken, idArea, idSector).then((data) => setData(data));
-  }, [accessToken, idArea, idSector]);
+const Todo = ({ idArea, idSector }: { idArea: number; idSector: number }) => {
+  const { data } = useTodo({ idArea, idSector });
 
   if (!data) {
     return <Loading />;
   }
+
   if (data.sectors.length === 0) {
     return <>Empty list.</>;
   }
+
   return (
     <>
       <Header as="h4">

--- a/src/components/common/top/top.tsx
+++ b/src/components/common/top/top.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Loading } from "../widgets/widgets";
 import { Table, Header, Image } from "semantic-ui-react";
 import { Link } from "react-router-dom";
-import { getTop } from "../../../api";
+import { useTop } from "../../../api";
 
 type TopProps = {
   idArea: number;
@@ -10,13 +10,7 @@ type TopProps = {
 };
 
 const Top = ({ idArea, idSector }: TopProps) => {
-  const [top, setTop] = useState<Awaited<ReturnType<typeof getTop>>>();
-
-  useEffect(() => {
-    getTop(idArea, idSector).then((res) => {
-      setTop(res);
-    });
-  }, [idArea, idSector]);
+  const { data: top } = useTop({ idArea, idSector });
 
   if (!top) {
     return <Loading />;


### PR DESCRIPTION
Continue the data-fetching improvement crusade with improve the data-fetching experience with the introduction of
`@tanstack/react-query` to fetching of the Top and Todo tabs.

This prevents loading-flickering on subsequent navigations.