### PR TITLE
feat: Provide /meta to the whole app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,19 @@ import { Container } from "semantic-ui-react";
 import Header from "./components/Header";
 import AppRoutes from "./components/AppRoutes";
 import Footer from "./components/Footer";
+import { MetaProvider } from "./components/common/meta";
 
 const App = () => {
   return (
-    <div style={{ background: "#F5F5F5" }}>
-      <Header />
-      <Container style={{ marginTop: "1em" }}>
-        <AppRoutes />
-      </Container>
-      <Footer />
-    </div>
+    <MetaProvider>
+      <div style={{ background: "#F5F5F5" }}>
+        <Header />
+        <Container style={{ marginTop: "1em" }}>
+          <AppRoutes />
+        </Container>
+        <Footer />
+      </div>
+    </MetaProvider>
   );
 };
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,35 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Container, Dropdown, Image, Menu, Icon } from "semantic-ui-react";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import SearchBox from "./common/search-box/search-box";
-import { getBaseUrl, getMeta } from "../api";
+import { getBaseUrl } from "../api";
+import { useMeta } from "./common/meta";
 
 const Navigation = () => {
-  const {
-    isLoading,
-    isAuthenticated,
-    loginWithRedirect,
-    logout,
-    getAccessTokenSilently,
-  } = useAuth0();
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [isSuperAdmin, setIsUserAdmin] = useState(false);
-  const [isBouldering, setIsBouldering] = useState(false);
-  const location = useLocation();
-  useEffect(() => {
-    const update = async () => {
-      const accessToken = isAuthenticated
-        ? await getAccessTokenSilently()
-        : null;
-      getMeta(accessToken).then((data) => {
-        setIsAdmin(data.metadata.isAdmin);
-        setIsUserAdmin(data.metadata.isSuperAdmin);
-        setIsBouldering(data.metadata.gradeSystem === "BOULDER");
-      });
-    };
-    update();
-  }, [isAuthenticated]);
+  const { isAdmin, isSuperAdmin, isAuthenticated, isBouldering } = useMeta();
+
+  const { isLoading, loginWithRedirect, logout } = useAuth0();
 
   return (
     <Menu attached="top" inverted compact borderless>

--- a/src/components/common/meta/index.ts
+++ b/src/components/common/meta/index.ts
@@ -1,0 +1,1 @@
+export { MetaProvider, useMeta } from "./meta";

--- a/src/components/common/meta/meta.tsx
+++ b/src/components/common/meta/meta.tsx
@@ -1,0 +1,75 @@
+import { createContext, useContext } from "react";
+import { useData } from "../../../api";
+
+type Grade = {
+  id: number;
+  grade: string;
+};
+
+type Type = {
+  id: number;
+  type: string;
+  subType: string;
+};
+
+type Metadata = {
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  isSuperAdmin: boolean;
+  title: string;
+  grades: Grade[];
+  defaultZoom: number;
+  defaultCenter: { lat: number; lng: number };
+  gradeSystem: "CLIMBING" | "BOULDER";
+  isBouldering: boolean;
+  types: Type[];
+};
+
+const DEFAULT_VALUE: Metadata = {
+  isAuthenticated: false,
+  isAdmin: false,
+  isSuperAdmin: false,
+  title: "",
+  grades: [],
+  defaultZoom: 9,
+  defaultCenter: {
+    lat: 60.893256420810616,
+    lng: 8.842601762708886,
+  },
+  gradeSystem: "CLIMBING",
+  isBouldering: false,
+  types: [],
+};
+
+const MetaContext = createContext<Metadata | undefined>(undefined);
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const useMeta = (): Metadata => {
+  const metadata = useContext(MetaContext);
+  if (!metadata) {
+    throw new Error("useMeta() can only be used inside of <MetaProvider />");
+  }
+  return metadata;
+};
+
+export const MetaProvider = ({ children }: Props) => {
+  const { data: meta } = useData<{ metadata: Metadata }>(`/meta`, {
+    transform: (resp) =>
+      resp.json().then((json) => ({
+        ...json,
+        metadata: {
+          ...json.metadata,
+          isBouldering: json.metadata.gradeSystem === "BOULDER",
+        },
+      })),
+  });
+
+  return (
+    <MetaContext.Provider value={meta?.metadata ?? DEFAULT_VALUE}>
+      {children}
+    </MetaContext.Provider>
+  );
+};


### PR DESCRIPTION
Instead of fetching `/meta` several times throughout the app, fetch it once and expose it to all components through a context provider.

> NOTE: There is still a remaining `/meta` call through the area-edit
>       function. This will be removed when that API gets cleaned up.