### PR TITLE
feat: Move /areas error from API to UI

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -219,18 +219,11 @@ export function useActivity({
 
 export function useArea(id: number) {
   return useData(`/areas?id=${id}`, {
-    transform: (response) => {
-      if (response.status === 500) {
-        return Promise.reject(
-          "Cannot find the specified area because it does not exist or you do not have sufficient permissions."
-        );
+    select: (data: any) => {
+      if (data.redirectUrl && data.redirectUrl != window.location.href) {
+        window.location.href = data.redirectUrl;
       }
-      return response.json().then((data) => {
-        if (data.redirectUrl && data.redirectUrl != window.location.href) {
-          window.location.href = data.redirectUrl;
-        }
-        return data;
-      });
+      return data;
     },
   });
 }

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -125,7 +125,9 @@ const Area = () => {
         style={{ backgroundColor: "#FFF" }}
         icon="meh"
         header="404"
-        content={String(error)}
+        content={
+          "Cannot find the specified area because it does not exist or you do not have sufficient permissions."
+        }
       />
     );
   } else if (!data || !data.id) {


### PR DESCRIPTION
If the requested area can't be found (invalid ID, insufficient permissions, etc), a message should be shown to the end user. This already happens today. However it does so in the API layer.

This change moves the error-detection (& string selection) up to the UI layer. In addition to being a bit more "normal", it also lets the data-fetching be simpler.