### PR TITLE
feat: Add a responsive navigation header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,19 @@ import { Container } from "semantic-ui-react";
 import Header from "./components/Header";
 import AppRoutes from "./components/AppRoutes";
 import Footer from "./components/Footer";
+import { MetaProvider } from "./components/common/meta";
 
 const App = () => {
   return (
-    <div style={{ background: "#F5F5F5" }}>
-      <Header />
-      <Container style={{ marginTop: "1em" }}>
-        <AppRoutes />
-      </Container>
-      <Footer />
-    </div>
+    <MetaProvider>
+      <div style={{ background: "#F5F5F5" }}>
+        <Header />
+        <Container style={{ marginTop: "1em" }}>
+          <AppRoutes />
+        </Container>
+        <Footer />
+      </div>
+    </MetaProvider>
   );
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Navigation from "./Navigation";
+import { Navigation } from "./Navigation";
 
 function Header() {
   return <Navigation />;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,35 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Container, Dropdown, Image, Menu, Icon } from "semantic-ui-react";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import SearchBox from "./common/search-box/search-box";
-import { getBaseUrl, getMeta } from "../api";
+import { getBaseUrl } from "../api";
+import { useMeta } from "./common/meta";
 
 const Navigation = () => {
-  const {
-    isLoading,
-    isAuthenticated,
-    loginWithRedirect,
-    logout,
-    getAccessTokenSilently,
-  } = useAuth0();
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [isSuperAdmin, setIsUserAdmin] = useState(false);
-  const [isBouldering, setIsBouldering] = useState(false);
-  const location = useLocation();
-  useEffect(() => {
-    const update = async () => {
-      const accessToken = isAuthenticated
-        ? await getAccessTokenSilently()
-        : null;
-      getMeta(accessToken).then((data) => {
-        setIsAdmin(data.metadata.isAdmin);
-        setIsUserAdmin(data.metadata.isSuperAdmin);
-        setIsBouldering(data.metadata.gradeSystem === "BOULDER");
-      });
-    };
-    update();
-  }, [isAuthenticated]);
+  const { isAdmin, isSuperAdmin, isAuthenticated, isBouldering } = useMeta();
+
+  const { isLoading, loginWithRedirect, logout } = useAuth0();
 
   return (
     <Menu attached="top" inverted compact borderless>

--- a/src/components/Navigation/Navigation.css
+++ b/src/components/Navigation/Navigation.css
@@ -1,0 +1,32 @@
+/* The first menu items to be collapsed. */
+.nav-container .collapse-1 span {
+  display: unset;
+}
+
+@media screen and (max-width: 1199px) {
+  .nav-container .collapse-1 span {
+    display: none !important;
+  }
+}
+
+@media screen and (max-width: 991px) {
+  .nav-container .item span {
+    display: none !important;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .nav-container .item span {
+    display: unset !important;
+  }
+
+  .nav-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .nav-container .row-1 {
+    flex-basis: 100% !important;
+  }
+}

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -2,61 +2,72 @@ import React from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Container, Dropdown, Image, Menu, Icon } from "semantic-ui-react";
 import { Link } from "react-router-dom";
-import SearchBox from "./common/search-box/search-box";
-import { getBaseUrl } from "../api";
-import { useMeta } from "./common/meta";
+import SearchBox from "../common/search-box/search-box";
+import { useMeta } from "../common/meta";
+import "./Navigation.css";
 
-const Navigation = () => {
+export const Navigation = () => {
   const { isAdmin, isSuperAdmin, isAuthenticated, isBouldering } = useMeta();
 
   const { isLoading, loginWithRedirect, logout } = useAuth0();
 
   return (
     <Menu attached="top" inverted compact borderless>
-      <Container>
-        <Menu.Item header as={Link} to="/">
-          <Image size="mini" src="/png/buldreinfo.png" />
+      <Container className="nav-container">
+        <div
+          style={{ display: "flex", flexDirection: "row", flex: 1 }}
+          className="row-1"
+        >
+          <Menu.Item header as={Link} to="/">
+            <Image size="mini" src="/png/buldreinfo.png" />
+          </Menu.Item>
+          <Menu.Item as={SearchBox} style={{ flex: 1 }} />
+        </div>
+        <Menu.Item as={Link} to="/browse">
+          <Icon name="list" />
+          <span>Areas</span>
         </Menu.Item>
-        <Menu.Item as={SearchBox} style={{ maxWidth: "35vw" }} />
-        <Dropdown item simple icon="ellipsis vertical">
-          <Dropdown.Menu>
-            <Dropdown.Item as={Link} to="/browse">
-              <Icon name="list" />
-              Browse areas
-            </Dropdown.Item>
-            <Dropdown.Item as={Link} to="/toc">
-              <Icon name="database" />
-              Table of Contents
-            </Dropdown.Item>
-            <Dropdown.Item as={Link} to="/cg">
-              <Icon name="area graph" />
-              Content Graph
-            </Dropdown.Item>
-            <Dropdown.Divider />
-            <Dropdown.Item as={Link} to="/filter">
-              <Icon name="find" />
-              Filter
-            </Dropdown.Item>
-            {!isBouldering && (
-              <Dropdown.Item as={Link} to="/dangerous">
-                <Icon name="warning sign" />
-                Marked as dangerous
-              </Dropdown.Item>
-            )}
-            <Dropdown.Divider />
-            <Dropdown.Item as={Link} to="/webcam-map">
-              <Icon name="camera" />
-              Webcam Map
-            </Dropdown.Item>
-            <Dropdown.Item as={Link} to="/about">
-              <Icon name="info" />
-              About
-            </Dropdown.Item>
-          </Dropdown.Menu>
-        </Dropdown>
+        <Menu.Item as={Link} to="/toc">
+          <Icon name="database" />
+          <span>{isBouldering ? "Problems" : "Routes"}</span>
+        </Menu.Item>
+        {!isBouldering && (
+          <Menu.Item as={Link} to="/dangerous">
+            <Icon name="warning sign" />
+            <span>Dangerous</span>
+          </Menu.Item>
+        )}
+        <Menu.Item as={Link} to="/filter">
+          <Icon name="find" />
+          <span>Filter</span>
+        </Menu.Item>
+        <Menu.Item as={Link} to="/cg" className="collapse-1">
+          <Icon name="chart bar" />
+          <span>Graph</span>
+        </Menu.Item>
+        <Menu.Item as={Link} to="/webcam-map" className="collapse-1">
+          <Icon name="camera" />
+          <span>Webcams</span>
+        </Menu.Item>
+        <Menu.Item as={Link} to="/about" className="collapse-1">
+          <Icon name="info" />
+          <span>About</span>
+        </Menu.Item>
         {!isLoading &&
           (isAuthenticated ? (
-            <Dropdown item simple icon="user">
+            <Dropdown
+              item
+              simple
+              labeled
+              trigger={
+                <>
+                  <Icon name="user" />
+                  <span>Account</span>
+                </>
+              }
+              icon={null}
+              className="collapse-1"
+            >
               <Dropdown.Menu>
                 <Dropdown.Item as={Link} to="/user">
                   <Icon name="user" />
@@ -96,7 +107,7 @@ const Navigation = () => {
                 <Dropdown.Item
                   as="a"
                   onClick={() =>
-                    logout({ logoutParams: { returnTo: getBaseUrl() } })
+                    logout({ logoutParams: { returnTo: window.origin } })
                   }
                 >
                   <Icon name="sign out" />
@@ -110,12 +121,13 @@ const Navigation = () => {
               onClick={() =>
                 loginWithRedirect({ appState: { returnTo: location.pathname } })
               }
-              icon="sign in"
-            />
+              className="collapse-1"
+            >
+              <Icon name="user outline" />
+              <span>Sign in</span>
+            </Menu.Item>
           ))}
       </Container>
     </Menu>
   );
 };
-
-export default Navigation;

--- a/src/components/Navigation/index.ts
+++ b/src/components/Navigation/index.ts
@@ -1,0 +1,1 @@
+export { Navigation } from "./Navigation";

--- a/src/components/common/meta/index.ts
+++ b/src/components/common/meta/index.ts
@@ -1,0 +1,1 @@
+export { MetaProvider, useMeta } from "./meta";

--- a/src/components/common/meta/meta.tsx
+++ b/src/components/common/meta/meta.tsx
@@ -1,0 +1,75 @@
+import { createContext, useContext } from "react";
+import { useData } from "../../../api";
+
+type Grade = {
+  id: number;
+  grade: string;
+};
+
+type Type = {
+  id: number;
+  type: string;
+  subType: string;
+};
+
+type Metadata = {
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  isSuperAdmin: boolean;
+  title: string;
+  grades: Grade[];
+  defaultZoom: number;
+  defaultCenter: { lat: number; lng: number };
+  gradeSystem: "CLIMBING" | "BOULDER";
+  isBouldering: boolean;
+  types: Type[];
+};
+
+const DEFAULT_VALUE: Metadata = {
+  isAuthenticated: false,
+  isAdmin: false,
+  isSuperAdmin: false,
+  title: "",
+  grades: [],
+  defaultZoom: 9,
+  defaultCenter: {
+    lat: 60.893256420810616,
+    lng: 8.842601762708886,
+  },
+  gradeSystem: "CLIMBING",
+  isBouldering: false,
+  types: [],
+};
+
+const MetaContext = createContext<Metadata | undefined>(undefined);
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const useMeta = (): Metadata => {
+  const metadata = useContext(MetaContext);
+  if (!metadata) {
+    throw new Error("useMeta() can only be used inside of <MetaProvider />");
+  }
+  return metadata;
+};
+
+export const MetaProvider = ({ children }: Props) => {
+  const { data: meta } = useData<{ metadata: Metadata }>(`/meta`, {
+    transform: (resp) =>
+      resp.json().then((json) => ({
+        ...json,
+        metadata: {
+          ...json.metadata,
+          isBouldering: json.metadata.gradeSystem === "BOULDER",
+        },
+      })),
+  });
+
+  return (
+    <MetaContext.Provider value={meta?.metadata ?? DEFAULT_VALUE}>
+      {children}
+    </MetaContext.Provider>
+  );
+};


### PR DESCRIPTION
The current navigation header isn't terribly responsive to device sizes.
It would be nice to work well on small devices (especially with
touch-input) as well as on large devices.

This change makes the top navigation bar responsive and attempts to be
more user-friendly. Specifically:

1. On wide screens, all of the items are shown, with icons and text.
2. On less-wide screens, some of the "secondary" items are collapsed to
   just icons.
3. On even smaller screens, all of the items will be reduced to just
   icons.
4. On very small screens, it will take on a multi-line format, with the
   first line being the home button and search bar, and the rest of the
   items being slotted into however many rows are necessary. Devices of
   this size are generally touch-input devices, so the text is included
   alongside the icon for finger-friendliness.

In the first 3 scenarios, the search box is dynamic and will expand to
fill up any "remaining" room that might exist (due to differences in the
users' devices, such as font size).

https://github.com/jossi87/climbing-web/assets/418560/3cd8ac8f-65cc-4cef-a8e4-8f2af2d140a6

Fixes jossi87/climbing-web#8