### PR TITLE
chore: Don't plumb around navigate

### DIFF
--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentProps } from "react";
 import { Helmet } from "react-helmet";
-import { Link, useParams, useNavigate } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import ChartGradeDistribution from "./common/chart-grade-distribution/chart-grade-distribution";
 import Top from "./common/top/top";
 import Activity from "./common/activity/activity";
@@ -103,7 +103,6 @@ const Area = () => {
   const accessToken = useAccessToken();
   const { areaId } = useParams();
   const { data, error, refetch } = useArea(parseInt(areaId ?? "0"));
-  const navigate = useNavigate();
 
   const md = new Remarkable({ breaks: true }).use(linkify);
   // open links in new windows
@@ -208,7 +207,6 @@ const Area = () => {
             polylines={polylines}
             defaultCenter={defaultCenter}
             defaultZoom={defaultZoom}
-            navigate={navigate}
             onMouseClick={null}
             onMouseMove={null}
             showSateliteImage={false}

--- a/src/components/AreaEdit.tsx
+++ b/src/components/AreaEdit.tsx
@@ -312,7 +312,6 @@ const AreaEdit = () => {
                 defaultZoom={defaultZoom}
                 onMouseClick={onMarkerClick}
                 onMouseMove={null}
-                navigate={navigate}
                 polylines={null}
                 outlines={null}
                 height={"300px"}

--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -105,7 +105,6 @@ const Browse = () => {
         markers={markers}
         defaultCenter={data.metadata.defaultCenter}
         defaultZoom={data.metadata.defaultZoom}
-        navigate={navigate}
         polylines={null}
         outlines={null}
         onMouseClick={null}

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Leaflet from "./common/leaflet/leaflet";
 import { Loading } from "./common/widgets/widgets";
 import {
@@ -27,7 +27,6 @@ enum OrderBy {
 
 const Filter = () => {
   const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const navigate = useNavigate();
   const [meta, setMeta] = useState<any>(null);
   const [grades, setGrades] = useLocalStorage<number[]>("filter_grades", []);
   const [disciplines, setDisciplines] = useLocalStorage<number[]>(
@@ -292,7 +291,6 @@ const Filter = () => {
               }))}
             defaultCenter={meta.metadata.defaultCenter}
             defaultZoom={meta.metadata.defaultZoom}
-            navigate={navigate}
             polylines={null}
             outlines={null}
             onMouseClick={null}

--- a/src/components/Problem.tsx
+++ b/src/components/Problem.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, ComponentProps } from "react";
 import { Helmet } from "react-helmet";
-import { Link, useParams, useNavigate } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import Leaflet from "./common/leaflet/leaflet";
 import { calculateDistance } from "./common/leaflet/distance-math";
 import Media from "./common/media/media";
@@ -49,7 +49,6 @@ const Problem = () => {
   const [showHiddenMedia, setShowHiddenMedia] = useState(false);
   const [reload, setReload] = useState(true);
   const { problemId } = useParams();
-  const navigate = useNavigate();
 
   useEffect(() => {
     if (!isLoading && (reload || (data != null && data.id != problemId))) {
@@ -251,7 +250,6 @@ const Problem = () => {
             polylines={polylines}
             defaultCenter={{ lat: markers[0].lat, lng: markers[0].lng }}
             defaultZoom={16}
-            navigate={navigate}
             onMouseClick={null}
             onMouseMove={null}
             showSateliteImage={true}

--- a/src/components/ProblemEdit.tsx
+++ b/src/components/ProblemEdit.tsx
@@ -581,7 +581,6 @@ const ProblemEdit = () => {
                 defaultZoom={defaultZoom}
                 onMouseClick={onMapClick}
                 onMouseMove={null}
-                navigate={navigate}
                 polylines={null}
                 outlines={null}
                 height={"300px"}

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
-import { Link, useParams, useNavigate } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import ProblemList from "./common/problem-list/problem-list";
 import ChartGradeDistribution from "./common/chart-grade-distribution/chart-grade-distribution";
 import Top from "./common/top/top";
@@ -103,7 +103,6 @@ const Sector = () => {
   const accessToken = useAccessToken();
   const { sectorId } = useParams();
   const { data: data, error, refetch, isLoading } = useSector(sectorId);
-  const navigate = useNavigate();
 
   if (error) {
     return (
@@ -217,7 +216,6 @@ const Sector = () => {
             polylines={polylines}
             defaultCenter={defaultCenter}
             defaultZoom={defaultZoom}
-            navigate={navigate}
             onMouseClick={null}
             onMouseMove={null}
             showSateliteImage={isBouldering}

--- a/src/components/SectorEdit.tsx
+++ b/src/components/SectorEdit.tsx
@@ -463,7 +463,6 @@ const SectorEdit = () => {
                   defaultZoom={defaultZoom}
                   onMouseClick={onMapMouseClick}
                   onMouseMove={null}
-                  navigate={navigate}
                   height={"300px"}
                   showSateliteImage={isBouldering}
                   clusterMarkers={false}

--- a/src/components/Sites.tsx
+++ b/src/components/Sites.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import { Button } from "semantic-ui-react";
 import Leaflet from "./common/leaflet/leaflet";
 import { Loading } from "./common/widgets/widgets";
@@ -11,7 +11,7 @@ const Sites = () => {
   const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
   const [data, setData] = useState<any>(null);
   const { type } = useParams();
-  const navigate = useNavigate();
+
   useEffect(() => {
     if (data) {
       setData(null);
@@ -53,7 +53,6 @@ const Sites = () => {
       outlines={outlines}
       defaultCenter={data.metadata.defaultCenter}
       defaultZoom={data.metadata.defaultZoom}
-      navigate={navigate}
       markers={null}
       polylines={null}
       onMouseClick={null}

--- a/src/components/WebcamMap.tsx
+++ b/src/components/WebcamMap.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import Leaflet from "./common/leaflet/leaflet";
 import { Segment, Header, Icon } from "semantic-ui-react";
@@ -8,7 +8,6 @@ import { useData } from "../api";
 const WebcamMap = () => {
   const { data } = useData(`/cameras`);
   const { json } = useParams();
-  const navigate = useNavigate();
 
   if (!data) {
     return <Loading />;
@@ -69,7 +68,6 @@ const WebcamMap = () => {
           outlines={null}
           defaultCenter={defaultCenter}
           defaultZoom={defaultZoom}
-          navigate={navigate}
           markers={markers}
           polylines={null}
           onMouseClick={null}

--- a/src/components/common/leaflet/leaflet.tsx
+++ b/src/components/common/leaflet/leaflet.tsx
@@ -38,7 +38,6 @@ function MapEvent({ onMouseClick, onMouseMove }) {
 
 const Leaflet = ({
   autoZoom,
-  navigate,
   markers,
   outlines,
   polylines,
@@ -122,7 +121,6 @@ const Leaflet = ({
     const markersWithoutRock = markers.filter((m) => !m.rock);
     markerGroup = (
       <Markers
-        navigate={navigate}
         opacity={opacity}
         markers={[...rockMarkers, ...markersWithoutRock]}
         addEventHandlers={addEventHandlers}
@@ -132,7 +130,6 @@ const Leaflet = ({
   } else {
     markerGroup = (
       <Markers
-        navigate={navigate}
         opacity={opacity}
         markers={markers}
         addEventHandlers={addEventHandlers}
@@ -226,7 +223,6 @@ const Leaflet = ({
       <FeatureGroup>
         {markerGroup}
         <Polygons
-          navigate={navigate}
           opacity={opacity}
           outlines={outlines}
           addEventHandlers={addEventHandlers}

--- a/src/components/common/leaflet/markers.tsx
+++ b/src/components/common/leaflet/markers.tsx
@@ -7,14 +7,15 @@ import {
   weatherIcon,
   rockIcon,
 } from "./icons";
+import { useNavigate } from "react-router";
 
 export default function Markers({
-  navigate,
   opacity,
   markers,
   addEventHandlers,
   flyToId,
 }) {
+  const navigate = useNavigate();
   const map = useMap();
   const markerRefs = useRef({});
   useEffect(() => {

--- a/src/components/common/leaflet/polygons.tsx
+++ b/src/components/common/leaflet/polygons.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { Polygon, Tooltip } from "react-leaflet";
+import { useNavigate } from "react-router";
 
-export default function Polygons({
-  navigate,
-  opacity,
-  outlines,
-  addEventHandlers,
-}) {
+export default function Polygons({ opacity, outlines, addEventHandlers }) {
+  const navigate = useNavigate();
   if (!outlines) {
     return null;
   }

--- a/src/components/common/profile/profile-statistics.tsx
+++ b/src/components/common/profile/profile-statistics.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Chart from "../chart/chart";
 import ProblemList from "../problem-list/problem-list";
 import Leaflet from "../../common/leaflet/leaflet";
@@ -103,7 +103,7 @@ const ProfileStatistics = ({
   const [data, setData] =
     useState<Awaited<ReturnType<typeof getProfileStatistics>>>();
   const [isSaving, setIsSaving] = useState(false);
-  const navigate = useNavigate();
+
   useEffect(() => {
     if (data) {
       setData(undefined);
@@ -224,7 +224,6 @@ const ProfileStatistics = ({
             markers={markers}
             defaultCenter={defaultCenter}
             defaultZoom={defaultZoom}
-            navigate={navigate}
             polylines={null}
             outlines={null}
             onMouseClick={null}

--- a/src/components/common/profile/profile-todo.tsx
+++ b/src/components/common/profile/profile-todo.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Leaflet from "../../common/leaflet/leaflet";
 import { Loading, LockSymbol } from "../../common/widgets/widgets";
 import { List, Segment } from "semantic-ui-react";
@@ -20,7 +20,7 @@ const ProfileTodo = ({
 }: ProfileTodoProps) => {
   const [data, setData] =
     useState<Awaited<ReturnType<typeof getProfileTodo>>>();
-  const navigate = useNavigate();
+
   useEffect(() => {
     if (data) {
       setData(undefined);
@@ -60,7 +60,6 @@ const ProfileTodo = ({
           markers={markers}
           defaultCenter={defaultCenter}
           defaultZoom={defaultZoom}
-          navigate={navigate}
           polylines={null}
           outlines={null}
           onMouseClick={null}


### PR DESCRIPTION
The `Leaflet` components need a `navigate` instance. However, instead of plumbing it in from the outside (at each callsite), those components can obtain (& own) their own instances using `useNavigate()`.