### PR TITLE
border added to the id-label for the selected route in the topo pic

### DIFF
--- a/src/components/common/media/svg.tsx
+++ b/src/components/common/media/svg.tsx
@@ -174,10 +174,12 @@ const Svg = ({
           />
           <rect
             fill="#000000"
+            stroke-width={r / 6}
+            stroke={svg.problemId === optProblemId ? '#FFFFFF' : 'none'}
             x={x - r}
             y={y - r}
-            width={r * 2}
-            height={r * 1.9}
+            width={r * 2.1}
+            height={r * 2}
             rx={r / 3}
           />
           <text


### PR DESCRIPTION
I've added a white, thin border to the id-label of the selected route in the topo pic for enhanced visibility like discussed in issue 
#18.