### PR TITLE
fix: svg attributes inside react code must be camelCase

### DIFF
--- a/src/components/common/media/svg.tsx
+++ b/src/components/common/media/svg.tsx
@@ -174,7 +174,7 @@ const Svg = ({
           />
           <rect
             fill="#000000"
-            stroke-width={r / 6}
+            strokeWidth={r / 6}
             stroke={svg.problemId === optProblemId ? '#FFFFFF' : 'none'}
             x={x - r}
             y={y - r}


### PR DESCRIPTION
svg attributes inside react must be camelCase, not hyphened. Fixed previous addition from stroke-width to strokeWidth