### PR TITLE
fix: Invalidate the cache after edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@auth0/auth0-react": "^2.1.1",
     "@react-leaflet/core": "^2.1.0",
     "@tanstack/react-query": "^4.29.17",
+    "@tanstack/react-query-devtools": "^4.29.17",
     "atob": "^2.1.2",
     "classnames": "^2.3.2",
     "express": "^4.18.2",

--- a/src/api.ts
+++ b/src/api.ts
@@ -56,8 +56,7 @@ export function useData<T = any>(
 ) {
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
   return useQuery<any>({
-    queryKey: [urlSuffix, isAuthenticated],
-    queryHash: `auth=${isAuthenticated}/${urlSuffix}`,
+    queryKey: [urlSuffix, { isAuthenticated }],
     queryFn: async () => {
       const accessToken = isAuthenticated
         ? await getAccessTokenSilently()
@@ -789,7 +788,7 @@ export function getSvgEdit(
         name: res.name,
         grade: res.grade,
         lockedAdmin: res.lockedAdmin,
-        lockedSuperadmin: res.lockedSuperadmin
+        lockedSuperadmin: res.lockedSuperadmin,
       };
     })
     .catch((error) => {

--- a/src/components/SectorEdit.tsx
+++ b/src/components/SectorEdit.tsx
@@ -21,8 +21,10 @@ import { useMeta } from "./common/meta";
 import { getSectorEdit, postSector, getSector, getArea } from "../api";
 import Leaflet from "./common/leaflet/leaflet";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 
 const SectorEdit = () => {
+  const client = useQueryClient();
   const {
     isLoading,
     isAuthenticated,
@@ -102,7 +104,18 @@ const SectorEdit = () => {
         data.newMedia,
         data.problemOrder
       )
-        .then((res) => {
+        .then(async (res) => {
+          // TODO: Remove this and use mutations instead.
+          await client.invalidateQueries({
+            predicate: (query) => {
+              const [urlSuffix] = query.queryKey;
+              if (!urlSuffix || !(typeof urlSuffix === "string")) {
+                return false;
+              }
+
+              return urlSuffix.startsWith(`/sectors?id=${data.id}`);
+            },
+          });
           navigate(res.destination);
         })
         .catch((error) => {
@@ -308,7 +321,9 @@ const SectorEdit = () => {
     return (
       <>
         <Helmet>
-          <title>Edit {data.name} | {meta.title}</title>
+          <title>
+            Edit {data.name} | {meta.title}
+          </title>
         </Helmet>
         <Message
           size="tiny"

--- a/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
+++ b/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
@@ -8,7 +8,6 @@ const ChartGradeDistribution = ({ accessToken, idArea, idSector, data }) => {
 
   useEffect(() => {
     if (idArea > 0 || idSector > 0) {
-      console.log(accessToken)
       getGradeDistribution(accessToken, idArea, idSector).then((res) => {
         setGradeDistribution(res);
       });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import App from "./App";
 import "./buldreinfo.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 function ErrorFallback({ error, resetErrorBoundary }) {
   const userAgent = navigator.userAgent;
@@ -90,6 +91,7 @@ const Index = () => (
         </Auth0ProviderWithNavigate>
       </ErrorBoundary>
     </BrowserRouter>
+    {process.env.REACT_APP_ENV === "development" && <ReactQueryDevtools />}
   </QueryClientProvider>
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,10 +1863,26 @@
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1" "^0.70.2"
     "@swagger-api/apidom-parser-adapter-yaml-1-2" "^0.70.1"
 
+"@tanstack/match-sorter-utils@^8.7.0":
+  version "8.8.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz#0b2864d8b7bac06a9f84cb903d405852cc40a457"
+  integrity sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==
+  dependencies:
+    remove-accents "0.4.2"
+
 "@tanstack/query-core@4.29.17":
   version "4.29.17"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.29.17.tgz#bbef3a30190732ae3554187702f6e34c5caaefd8"
   integrity sha512-iDbO8yZOpm1lqgq6L8mpxGbKaoiyZSjthxEB3WGU7mNPYss9q4H3Q67+e2xXGwkemEVmtEX/WwvtFitrvVU8TA==
+
+"@tanstack/react-query-devtools@^4.29.17":
+  version "4.29.17"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-4.29.17.tgz#1cad2697bf07c44139bd5d331aea9dbb5d11f606"
+  integrity sha512-Dgd7c7ToCzJrpuyDZ0Rwx5bXSqWICOaB8sNSzo8YtwpWXuJcQ074qgb0kko5/CzIVDxhbG8WX5dnUwr5Xqa++g==
+  dependencies:
+    "@tanstack/match-sorter-utils" "^8.7.0"
+    superjson "^1.10.0"
+    use-sync-external-store "^1.2.0"
 
 "@tanstack/react-query@^4.29.17":
   version "4.29.17"
@@ -3301,6 +3317,13 @@ cookie@0.5.0, cookie@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+copy-anything@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.5.tgz#2d92dce8c498f790fa7ad16b01a1ae5a45b020a0"
+  integrity sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==
+  dependencies:
+    is-what "^4.1.8"
 
 copy-to-clipboard@^3.3.1:
   version "3.3.3"
@@ -5305,6 +5328,11 @@ is-weakref@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
+is-what@^4.1.8:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.15.tgz#de43a81090417a425942d67b1ae86e7fae2eee0e"
+  integrity sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==
+
 is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
@@ -7158,6 +7186,11 @@ remarkable@^2.0.1:
     argparse "^1.0.10"
     autolinker "^3.11.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"
@@ -7906,6 +7939,13 @@ suncalc@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/suncalc/-/suncalc-1.9.0.tgz#26212353fae61edb287c2d558fc4932ecf0e1532"
   integrity sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A==
+
+superjson@^1.10.0:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.12.4.tgz#cfea35b0d1eb0f12d8b185f1d871272555f5a61f"
+  integrity sha512-vkpPQAxdCg9SLfPv5GPC5fnGrui/WryktoN9O5+Zif/14QIMjw+RITf/5LbBh+9QpBFb3KNvJth+puz2H8o6GQ==
+  dependencies:
+    copy-anything "^3.0.2"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
When making an edit to a resource (area, sector, problem), we need to make sure to invalidate the cache. Otherwise, we run the risk of showing the user stale data when they go back to the resource's page.

This is a temporary stop-gap -- in the future, we should go all-in on `useMutation(..)`, which will modify the cache and prevent a refetch at all. However, that'll take too long, so let's land this first.