### PR TITLE
fix: Refetch sectors after editing an image

### DIFF
--- a/src/components/common/widgets/widgets.tsx
+++ b/src/components/common/widgets/widgets.tsx
@@ -1,5 +1,13 @@
+import { useAuth0 } from "@auth0/auth0-react";
 import React from "react";
-import { Segment, Message, Icon, Popup, Label } from "semantic-ui-react";
+import {
+  Segment,
+  Message,
+  Icon,
+  Popup,
+  Label,
+  Button,
+} from "semantic-ui-react";
 import SunCalc from "suncalc";
 
 type LockSymbolProps = {
@@ -111,6 +119,23 @@ export function Loading() {
         We are fetching that content for you.
       </Message.Content>
     </Message>
+  );
+}
+
+export function NotLoggedIn() {
+  const { loginWithRedirect } = useAuth0();
+
+  return (
+    <Segment>
+      <h3>Authentication required</h3>
+      <Button
+        onClick={() => {
+          loginWithRedirect({ appState: { returnTo: location.pathname } });
+        }}
+      >
+        Log in
+      </Button>
+    </Segment>
   );
 }
 


### PR DESCRIPTION
After an image is edited, we send the user back to where they came from (likely the sector that they were viewing). However, the data that is shown on the screen is the _previous_ data, living in RAM.

In order to refetch this, we do a very heavy-handed refetch of **all** sectors. This is necessary because when we're editing an image, we don't know which sector(s) that image belongs to.

This is better than the bug, but it's not ideal.