### PR TITLE
fix: Do some heavy-handed cache invalidation

### DIFF
--- a/src/components/AreaEdit.tsx
+++ b/src/components/AreaEdit.tsx
@@ -99,19 +99,7 @@ const AreaEdit = () => {
         .then(async (res) => {
           // TODO: Remove this and use mutations instead.
           await client.invalidateQueries({
-            predicate: (query) => {
-              const queryKey = query.queryKey;
-              if (
-                Array.isArray(queryKey) &&
-                queryKey[1] &&
-                typeof queryKey[1] === "object"
-              ) {
-                if (queryKey[0] == '/areas' && (query.queryKey[1] as any).id == areaId) {
-                  return true;
-                }
-              }
-              return false;
-            },
+            predicate: () => true,
           });
           return navigate(res.destination);
         })

--- a/src/components/Permissions.tsx
+++ b/src/components/Permissions.tsx
@@ -14,8 +14,10 @@ import {
 import { Link, useLocation } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
 import { InsufficientPrivileges } from "./common/widgets/widgets";
+import { useQueryClient } from "@tanstack/react-query";
 
 const Permissions = () => {
+  const client = useQueryClient();
   const {
     isLoading,
     isAuthenticated,
@@ -142,6 +144,9 @@ const Permissions = () => {
                             superadminWrite
                           )
                             .then(() => {
+                              client.invalidateQueries({
+                                predicate: () => true,
+                              });
                               window.scrollTo(0, 0);
                               window.location.reload();
                             })

--- a/src/components/ProblemEdit.tsx
+++ b/src/components/ProblemEdit.tsx
@@ -225,25 +225,7 @@ const ProblemEdit = () => {
         .then(async (res) => {
           // TODO: Remove this and use mutations instead.
           await client.invalidateQueries({
-            predicate: (query) => {
-              const queryKey = query.queryKey;
-              if (
-                Array.isArray(queryKey) &&
-                queryKey[1] &&
-                typeof queryKey[1] === "object"
-              ) {
-                if (queryKey[0] == '/problem' && (query.queryKey[1] as any).id == data.id) {
-                  return true;
-                }
-                else if (queryKey[0] == '/sectors' && (query.queryKey[1] as any).id == data.sectorId) {
-                  return true;
-                }
-                else if (queryKey[0] == '/areas' && (query.queryKey[1] as any).id == data.areaId) {
-                  return true;
-                }
-              }
-              return false;
-            },
+            predicate: () => true,
           });
           if (addNew) {
             navigate(0);

--- a/src/components/ProblemEditMedia.tsx
+++ b/src/components/ProblemEditMedia.tsx
@@ -41,25 +41,7 @@ const ProblemEditMedia = () => {
         .then(async (res) => {
           // TODO: Remove this and use mutations instead.
           await client.invalidateQueries({
-            predicate: (query) => {
-              const queryKey = query.queryKey;
-              if (
-                Array.isArray(queryKey) &&
-                queryKey[1] &&
-                typeof queryKey[1] === "object"
-              ) {
-                if (queryKey[0] == '/problem' && (query.queryKey[1] as any).id == res.id) {
-                  return true;
-                }
-                else if (queryKey[0] == '/sectors' && (query.queryKey[1] as any).id == res.sectorId) {
-                  return true;
-                }
-                else if (queryKey[0] == '/areas' && (query.queryKey[1] as any).id == res.areaId) {
-                  return true;
-                }
-              }
-              return false;
-            },
+            predicate: () => true,
           });
           navigate(`/problem/${res.id}`);
         })

--- a/src/components/SectorEdit.tsx
+++ b/src/components/SectorEdit.tsx
@@ -107,22 +107,7 @@ const SectorEdit = () => {
         .then(async (res) => {
           // TODO: Remove this and use mutations instead.
           await client.invalidateQueries({
-            predicate: (query) => {
-              const queryKey = query.queryKey;
-              if (
-                Array.isArray(queryKey) &&
-                queryKey[1] &&
-                typeof queryKey[1] === "object"
-              ) {
-                if (queryKey[0] == '/sectors' && (query.queryKey[1] as any).id == data.id) {
-                  return true;
-                }
-                else if (queryKey[0] == '/areas' && (query.queryKey[1] as any).id == data.areaId) {
-                  return true;
-                }
-              }
-              return false;
-            },
+            predicate: () => true,
           });
           navigate(res.destination);
         })

--- a/src/components/SvgEdit.tsx
+++ b/src/components/SvgEdit.tsx
@@ -116,19 +116,7 @@ const SvgEdit = () => {
         .then(async () => {
           // TODO: Remove this and use mutations instead.
           await client.refetchQueries({
-            predicate: (query) => {
-              const queryKey = query.queryKey;
-              if (
-                Array.isArray(queryKey) &&
-                queryKey[1] &&
-                typeof queryKey[1] === "object"
-              ) {
-                if (queryKey[0] == '/problem' && (query.queryKey[1] as any).id == id) {
-                  return true;
-                }
-              }
-              return false;
-            },
+            predicate: () => true,
           });
           navigate(`/problem/${id}`);
         })


### PR DESCRIPTION
Until everything is migrated to using `@tanstack/react-query`, we're running into consistency problems when it comes to mutations. For now, whenever there's a mutation, just invalidate everything in the the local cache.