### PR TITLE
fix: Invalidate the cache on mutations

### DIFF
--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -104,7 +104,7 @@ const Area = () => {
   const accessToken = useAccessToken();
   const meta = useMeta();
   const { areaId } = useParams();
-  const { data, error, refetch } = useAreas(parseInt(areaId ?? "0"));
+  const { data, error } = useAreas(parseInt(areaId ?? "0"));
 
   const md = new Remarkable({ breaks: true }).use(linkify);
   // open links in new windows
@@ -179,7 +179,6 @@ const Area = () => {
           <Media
             isAdmin={meta.isAdmin}
             numPitches={0}
-            removeMedia={() => refetch()}
             media={data[0].media}
             optProblemId={null}
             isBouldering={meta.isBouldering}
@@ -471,7 +470,6 @@ const Area = () => {
                   <Media
                     isAdmin={meta.isAdmin}
                     numPitches={0}
-                    removeMedia={() => window.location.reload()}
                     media={data[0].triviaMedia}
                     optProblemId={null}
                     isBouldering={meta.isBouldering}

--- a/src/components/AreaEdit.tsx
+++ b/src/components/AreaEdit.tsx
@@ -19,10 +19,8 @@ import { useMeta } from "./common/meta";
 import { getAreaEdit, postArea } from "../api";
 import { Loading, InsufficientPrivileges } from "./common/widgets/widgets";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 
 const AreaEdit = () => {
-  const client = useQueryClient();
   const {
     isLoading,
     isAuthenticated,
@@ -97,10 +95,6 @@ const AreaEdit = () => {
         data.sectorOrder
       )
         .then(async (res) => {
-          // TODO: Remove this and use mutations instead.
-          await client.invalidateQueries({
-            predicate: () => true,
-          });
           return navigate(res.destination);
         })
         .catch((error) => {

--- a/src/components/DataReloader/DataReloader.tsx
+++ b/src/components/DataReloader/DataReloader.tsx
@@ -1,0 +1,47 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+export const DATA_MUTATION_EVENT = "brattelinjer/refetch";
+
+const HANDLERS = {
+  nop: async (...args) => {
+    if (process.env.REACT_APP_ENV === "development") {
+      console.debug("DataReloader: stubbed-out reload", ...args);
+    }
+  },
+  invalidate: (client) => client.invalidateQueries({ predicate: () => true }),
+  refetch: (client) => client.refetchQueries({ predicate: () => true }),
+} as const;
+
+export type ConsistencyAction = keyof typeof HANDLERS;
+
+/**
+ * Take a possibly-overly-conservative approach to data consistency: whenever
+ * there's a {@code DATA_MUTATION_EVENT} broadcast, ensure that the cached data
+ * is consistent, by whatever is requested in the event.
+ *
+ * This is a bit aggressive, but until we get the data consistency under
+ * control, this is the simplest way to ensure that the UI remains correct. In
+ * the future, we should be able to use {@code @tanstack/react-query}'s
+ * functionalities to directly update the cache after mutations. However, that
+ * day is not today, and the side-effects are too deeply-wired to invalidate
+ * query-by-query.
+ *
+ * So, here we are!
+ */
+export const DataReloader = ({ children }: { children: React.ReactNode }) => {
+  const client = useQueryClient();
+  useEffect(() => {
+    const onEvent = (event: CustomEvent) => {
+      const mode = event?.detail?.mode ?? "nop";
+      HANDLERS[mode in HANDLERS ? mode : "nop"]?.(client);
+    };
+
+    window.addEventListener(DATA_MUTATION_EVENT, onEvent);
+    return () => {
+      window.removeEventListener(DATA_MUTATION_EVENT, onEvent);
+    };
+  }, [client]);
+
+  return children;
+};

--- a/src/components/DataReloader/index.ts
+++ b/src/components/DataReloader/index.ts
@@ -1,0 +1,2 @@
+export { DataReloader, DATA_MUTATION_EVENT } from "./DataReloader";
+export type { ConsistencyAction } from "./DataReloader";

--- a/src/components/Permissions.tsx
+++ b/src/components/Permissions.tsx
@@ -14,10 +14,8 @@ import {
 import { Link, useLocation } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
 import { InsufficientPrivileges } from "./common/widgets/widgets";
-import { useQueryClient } from "@tanstack/react-query";
 
 const Permissions = () => {
-  const client = useQueryClient();
   const {
     isLoading,
     isAuthenticated,
@@ -144,9 +142,6 @@ const Permissions = () => {
                             superadminWrite
                           )
                             .then(() => {
-                              client.invalidateQueries({
-                                predicate: () => true,
-                              });
                               window.scrollTo(0, 0);
                               window.location.reload();
                             })

--- a/src/components/Problem.tsx
+++ b/src/components/Problem.tsx
@@ -39,7 +39,6 @@ import {
 import TickModal from "./common/tick-modal/tick-modal";
 import CommentModal from "./common/comment-modal/comment-modal";
 import Linkify from "react-linkify";
-import { useQueryClient } from "@tanstack/react-query";
 
 const componentDecorator = (href, text, key) => (
   <a href={href} key={key} target="_blank" rel="noreferrer">
@@ -205,34 +204,36 @@ const ProblemComments = ({
   showHiddenMedia: boolean;
   onShowCommentModal: (comment: any) => void;
 }) => {
-  const client = useQueryClient();
   const accessToken = useAccessToken();
   const meta = useMeta();
   const { data } = useProblem(problemId, showHiddenMedia);
 
   function flagAsDangerous({ id, message }) {
     if (confirm("Are you sure you want to flag this comment?")) {
-      postComment(accessToken, id, data.id, message, true, false, false, [])
-        .then(async () => {
-          await client.invalidateQueries({ predicate: () => true });
-        })
-        .catch((error) => {
-          console.warn(error);
-          alert(error.toString());
-        });
+      postComment(
+        accessToken,
+        id,
+        data.id,
+        message,
+        true,
+        false,
+        false,
+        []
+      ).catch((error) => {
+        console.warn(error);
+        alert(error.toString());
+      });
     }
   }
 
   function deleteComment({ id }) {
     if (confirm("Are you sure you want to delete this comment?")) {
-      postComment(accessToken, id, data.id, null, false, false, true, [])
-        .then(async () => {
-          await client.invalidateQueries({ predicate: () => true });
-        })
-        .catch((error) => {
+      postComment(accessToken, id, data.id, null, false, false, true, []).catch(
+        (error) => {
           console.warn(error);
           alert(error.toString());
-        });
+        }
+      );
     }
   }
 
@@ -286,11 +287,6 @@ const ProblemComments = ({
                     <Media
                       isAdmin={meta.isAdmin}
                       numPitches={data.sections?.length || 0}
-                      removeMedia={async () =>
-                        await client.invalidateQueries({
-                          predicate: () => true,
-                        })
-                      }
                       media={c.media}
                       optProblemId={null}
                       isBouldering={meta.isBouldering}
@@ -310,7 +306,6 @@ const ProblemComments = ({
 };
 
 const Problem = () => {
-  const client = useQueryClient();
   const accessToken = useAccessToken();
   const { problemId } = useParams();
   const [showHiddenMedia, setShowHiddenMedia] = useState(false);
@@ -321,14 +316,10 @@ const Problem = () => {
   const [showCommentModal, setShowCommentModal] = useState<any>(null);
 
   function toggleTodo(problemId: number) {
-    postTodo(accessToken, problemId)
-      .then(async () => {
-        await client.invalidateQueries({ predicate: () => true });
-      })
-      .catch((error) => {
-        console.warn(error);
-        alert(error.toString());
-      });
+    postTodo(accessToken, problemId).catch((error) => {
+      console.warn(error);
+      alert(error.toString());
+    });
   }
 
   const onTickModalClose = () => {
@@ -385,9 +376,6 @@ const Problem = () => {
           <Media
             isAdmin={meta.isAdmin}
             numPitches={data.sections?.length || 0}
-            removeMedia={async () =>
-              await client.invalidateQueries({ predicate: () => true })
-            }
             media={data.media}
             optProblemId={data.id}
             isBouldering={meta.isBouldering}
@@ -563,7 +551,6 @@ const Problem = () => {
                   animated="fade"
                   onClick={async () => {
                     setShowHiddenMedia(!showHiddenMedia);
-                    await client.invalidateQueries({ predicate: () => true });
                   }}
                 >
                   <Button.Content hidden>Images</Button.Content>
@@ -811,11 +798,6 @@ const Problem = () => {
                     <Media
                       isAdmin={meta.isAdmin}
                       numPitches={data.sections?.length || 0}
-                      removeMedia={async () =>
-                        await client.invalidateQueries({
-                          predicate: () => true,
-                        })
-                      }
                       media={data.triviaMedia}
                       optProblemId={null}
                       isBouldering={meta.isBouldering}
@@ -946,11 +928,6 @@ const Problem = () => {
                               <Media
                                 isAdmin={meta.isAdmin}
                                 numPitches={data.sections?.length || 0}
-                                removeMedia={async () =>
-                                  await client.invalidateQueries({
-                                    predicate: () => true,
-                                  })
-                                }
                                 media={s.media}
                                 optProblemId={null}
                                 isBouldering={meta.isBouldering}

--- a/src/components/ProblemEdit.tsx
+++ b/src/components/ProblemEdit.tsx
@@ -30,10 +30,8 @@ import { Loading, InsufficientPrivileges } from "./common/widgets/widgets";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import { useQueryClient } from "@tanstack/react-query";
 
 const ProblemEdit = () => {
-  const client = useQueryClient();
   const {
     isLoading,
     isAuthenticated,
@@ -223,10 +221,6 @@ const ProblemEdit = () => {
         data.descent
       )
         .then(async (res) => {
-          // TODO: Remove this and use mutations instead.
-          await client.invalidateQueries({
-            predicate: () => true,
-          });
           if (addNew) {
             navigate(0);
           } else {

--- a/src/components/ProblemEditMedia.tsx
+++ b/src/components/ProblemEditMedia.tsx
@@ -5,10 +5,8 @@ import { getProblem, postProblemMedia } from "../api";
 import { Loading } from "./common/widgets/widgets";
 import { Segment, Button } from "semantic-ui-react";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 
 const ProblemEditMedia = () => {
-  const client = useQueryClient();
   const {
     isLoading,
     isAuthenticated,
@@ -39,10 +37,6 @@ const ProblemEditMedia = () => {
     getAccessTokenSilently().then((accessToken) => {
       postProblemMedia(accessToken, id, media)
         .then(async (res) => {
-          // TODO: Remove this and use mutations instead.
-          await client.invalidateQueries({
-            predicate: () => true,
-          });
           navigate(`/problem/${res.id}`);
         })
         .catch((error) => {

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -104,7 +104,7 @@ const Sector = () => {
   const accessToken = useAccessToken();
   const { sectorId } = useParams();
   const meta = useMeta();
-  const { data: data, error, refetch, isLoading } = useSector(sectorId);
+  const { data: data, error, isLoading } = useSector(sectorId);
 
   if (error) {
     return (
@@ -158,7 +158,6 @@ const Sector = () => {
             <Media
               isAdmin={meta.isAdmin}
               numPitches={0}
-              removeMedia={() => refetch()}
               media={media}
               optProblemId={null}
               isBouldering={isBouldering}
@@ -235,7 +234,6 @@ const Sector = () => {
           <Media
             isAdmin={meta.isAdmin}
             numPitches={0}
-            removeMedia={() => refetch()}
             media={topoImages}
             optProblemId={null}
             isBouldering={isBouldering}
@@ -457,7 +455,6 @@ const Sector = () => {
                   <Media
                     isAdmin={meta.isAdmin}
                     numPitches={0}
-                    removeMedia={() => window.location.reload()}
                     media={data.triviaMedia}
                     optProblemId={null}
                     isBouldering={isBouldering}

--- a/src/components/SectorEdit.tsx
+++ b/src/components/SectorEdit.tsx
@@ -21,10 +21,8 @@ import { useMeta } from "./common/meta";
 import { getSectorEdit, postSector, getSector, getArea } from "../api";
 import Leaflet from "./common/leaflet/leaflet";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 
 const SectorEdit = () => {
-  const client = useQueryClient();
   const {
     isLoading,
     isAuthenticated,
@@ -105,10 +103,6 @@ const SectorEdit = () => {
         data.problemOrder
       )
         .then(async (res) => {
-          // TODO: Remove this and use mutations instead.
-          await client.invalidateQueries({
-            predicate: () => true,
-          });
           navigate(res.destination);
         })
         .catch((error) => {

--- a/src/components/SvgEdit.tsx
+++ b/src/components/SvgEdit.tsx
@@ -10,10 +10,8 @@ import {
   NotLoggedIn,
 } from "./common/widgets/widgets";
 import { useNavigate, useParams } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 
 const SvgEdit = () => {
-  const client = useQueryClient();
   const [saving, setSaving] = useState(false);
   const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
   const [mediaId, setMediaId] = useState<any>(null);
@@ -115,11 +113,7 @@ const SvgEdit = () => {
         JSON.stringify(anchors),
         JSON.stringify(texts)
       )
-        .then(async () => {
-          // TODO: Remove this and use mutations instead.
-          await client.refetchQueries({
-            predicate: () => true,
-          });
+        .then(() => {
           navigate(`/problem/${id}`);
         })
         .catch((error) => {

--- a/src/components/Trash.tsx
+++ b/src/components/Trash.tsx
@@ -6,10 +6,8 @@ import { Segment, Icon, Header, List, Button, Image } from "semantic-ui-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
 import { InsufficientPrivileges } from "./common/widgets/widgets";
-import { useQueryClient } from "@tanstack/react-query";
 
 const Trash = () => {
-  const client = useQueryClient();
   const { isLoading, isAuthenticated, loginWithRedirect } = useAuth0();
   const accessToken = useAccessToken();
   const meta = useMeta();
@@ -62,14 +60,7 @@ const Trash = () => {
                               t.idProblem,
                               t.idMedia
                             )
-                              .then(async () => {
-                                // TODO: Remove this and use mutations instead.
-                                await client.invalidateQueries({
-                                  predicate: () => {
-                                    // Invalidate everything, restored item can be media (on area/sector/problem) or an area/sector/problem
-                                    return true;
-                                  },
-                                });
+                              .then(() => {
                                 let url;
                                 if (t.idArea > 0) {
                                   url = "/area/" + t.idArea;

--- a/src/components/common/comment-modal/comment-modal.tsx
+++ b/src/components/common/comment-modal/comment-modal.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { postComment, useAccessToken } from "./../../../api";
 import { Button, Modal, Form, TextArea } from "semantic-ui-react";
 import ImageUpload from "../image-upload/image-upload";
-import { useQueryClient } from "@tanstack/react-query";
 
 const CommentModal = ({
   comment,
@@ -21,7 +20,6 @@ const CommentModal = ({
     resolved: boolean;
   };
 }) => {
-  const client = useQueryClient();
   const accessToken = useAccessToken();
   const [message, setMessage] = useState(comment?.message ?? "");
   const [danger, setDanger] = useState(comment?.danger);
@@ -116,9 +114,8 @@ const CommentModal = ({
                 false,
                 media
               )
-                .then(async () => {
+                .then(() => {
                   onClose();
-                  await client.invalidateQueries({ predicate: () => true });
                 })
                 .catch((error) => {
                   console.warn(error);

--- a/src/components/common/media/media.tsx
+++ b/src/components/common/media/media.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, ComponentProps } from "react";
 import LazyLoad from "react-lazyload";
 import { useLocation } from "react-router-dom";
 import {
@@ -14,7 +14,6 @@ import MediaEditModal from "./media-edit-modal";
 import Svg from "./svg";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Loading } from "../widgets/widgets";
-import { useQueryClient } from "@tanstack/react-query";
 
 const style = {
   objectFit: "cover",
@@ -30,12 +29,15 @@ const style = {
 const Media = ({
   numPitches,
   media,
-  removeMedia,
   isAdmin,
   optProblemId,
   isBouldering,
-}) => {
-  const client = useQueryClient();
+}: Pick<ComponentProps<typeof MediaEditModal>, "numPitches"> &
+  Pick<ComponentProps<typeof MediaModal>, "optProblemId"> & {
+    media: any[];
+    isAdmin: boolean;
+    isBouldering: boolean;
+  }) => {
   const location = useLocation();
   const [m, setM] = useState<any>(null);
   const [editM, setEditM] = useState<any>(null);
@@ -100,7 +102,6 @@ const Media = ({
       getAccessTokenSilently().then((accessToken) => {
         deleteMedia(accessToken, id)
           .then(() => {
-            removeMedia(id);
             closeModal();
           })
           .catch((error) => {
@@ -118,8 +119,7 @@ const Media = ({
     ) {
       getAccessTokenSilently().then((accessToken) => {
         putMediaJpegRotate(accessToken, m.id, degrees)
-          .then(async () => {
-            await client.invalidateQueries({ predicate: () => true });
+          .then(() => {
             closeModal();
           })
           .catch((error) => {
@@ -132,8 +132,7 @@ const Media = ({
   function onMoveImageLeft() {
     getAccessTokenSilently().then((accessToken) => {
       moveMedia(accessToken, m.id, true, 0, 0)
-        .then(async () => {
-          await client.invalidateQueries({ predicate: () => true });
+        .then(() => {
           closeModal();
         })
         .catch((error) => {
@@ -145,8 +144,7 @@ const Media = ({
   function onMoveImageRight() {
     getAccessTokenSilently().then((accessToken) => {
       moveMedia(accessToken, m.id, false, 0, 0)
-        .then(async () => {
-          await client.invalidateQueries({ predicate: () => true });
+        .then(() => {
           closeModal();
         })
         .catch((error) => {
@@ -158,8 +156,7 @@ const Media = ({
   function onMoveImageToSector() {
     getAccessTokenSilently().then((accessToken) => {
       moveMedia(accessToken, m.id, false, m.enableMoveToIdSector, 0)
-        .then(async () => {
-          await client.invalidateQueries({ predicate: () => true });
+        .then(() => {
           closeModal();
         })
         .catch((error) => {
@@ -171,8 +168,7 @@ const Media = ({
   function onMoveImageToProblem() {
     getAccessTokenSilently().then((accessToken) => {
       moveMedia(accessToken, m.id, false, 0, m.enableMoveToIdProblem)
-        .then(async () => {
-          await client.invalidateQueries({ predicate: () => true });
+        .then(() => {
           closeModal();
         })
         .catch((error) => {
@@ -205,8 +201,7 @@ const Media = ({
           save={(mediaId, description, pitch, trivia) => {
             getAccessTokenSilently().then((accessToken) => {
               putMediaInfo(accessToken, mediaId, description, pitch, trivia)
-                .then(async () => {
-                  await client.invalidateQueries({ predicate: () => true });
+                .then(() => {
                   setEditM(null);
                 })
                 .catch((error) => {

--- a/src/components/common/profile/profile-media.tsx
+++ b/src/components/common/profile/profile-media.tsx
@@ -23,7 +23,6 @@ const ProfileMedia = ({ accessToken, userId, isBouldering, captured }) => {
       <Media
         numPitches={null}
         isAdmin={false}
-        removeMedia={null}
         media={data}
         optProblemId={null}
         isBouldering={isBouldering}

--- a/src/components/common/profile/profile-settings.tsx
+++ b/src/components/common/profile/profile-settings.tsx
@@ -2,10 +2,8 @@ import React from "react";
 import { Segment, Icon, Label, Header } from "semantic-ui-react";
 import { postUserRegion } from "../../../api";
 import { useNavigate } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 
 const ProfileSettings = ({ accessToken, userRegions }) => {
-  const client = useQueryClient();
   const navigate = useNavigate();
   if (!accessToken || !userRegions || userRegions.length === 0) {
     return <Segment>No data</Segment>;
@@ -31,8 +29,7 @@ const ProfileSettings = ({ accessToken, userRegions }) => {
               as="a"
               onClick={() => {
                 postUserRegion(accessToken, ur.id, true)
-                  .then(async () => {
-                    await client.invalidateQueries({ predicate: () => true });
+                  .then(() => {
                     navigate(0);
                   })
                   .catch((error) => {
@@ -54,8 +51,7 @@ const ProfileSettings = ({ accessToken, userRegions }) => {
               as="a"
               onClick={() => {
                 postUserRegion(accessToken, ur.id, false)
-                  .then(async () => {
-                    await client.invalidateQueries({ predicate: () => true });
+                  .then(() => {
                     navigate(0);
                   })
                   .catch((error) => {

--- a/src/components/common/search-box/search-box.tsx
+++ b/src/components/common/search-box/search-box.tsx
@@ -38,8 +38,12 @@ const SearchBox = (searchProps: SearchBoxProps) => {
 
   useEffect(() => {
     let canceled = false;
-    setLoading(true);
     const update = async () => {
+      if (!value) {
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
       const accessToken = isAuthenticated
         ? await getAccessTokenSilently()
         : null;

--- a/src/components/common/tick-modal/tick-modal.tsx
+++ b/src/components/common/tick-modal/tick-modal.tsx
@@ -16,7 +16,6 @@ import {
 } from "semantic-ui-react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import { useQueryClient } from "@tanstack/react-query";
 
 type TickModalProps = {
   open: boolean;
@@ -45,7 +44,6 @@ const TickModal = ({
   date: initialDate,
   enableTickRepeats,
 }: TickModalProps) => {
-  const client = useQueryClient();
   const accessToken = useAccessToken();
   const [comment, setComment] = useState(initialComment);
   const [grade, setGrade] = useState(initialGrade);
@@ -267,9 +265,8 @@ const TickModal = ({
                     grade,
                     repeats
                   )
-                    .then(async () => {
+                    .then(() => {
                       onClose();
-                      await client.invalidateQueries({ predicate: () => true });
                     })
                     .catch((error) => {
                       console.warn(error);
@@ -301,9 +298,8 @@ const TickModal = ({
                 grade,
                 repeats
               )
-                .then(async () => {
+                .then(() => {
                   onClose();
-                  await client.invalidateQueries({ predicate: () => true });
                 })
                 .catch((error) => {
                   console.warn(error);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import "./buldreinfo.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { DataReloader } from "./components/DataReloader";
 
 function ErrorFallback({ error, resetErrorBoundary }) {
   const userAgent = navigator.userAgent;
@@ -88,9 +89,11 @@ const Index = () => (
         FallbackComponent={ErrorFallback}
         onReset={() => window.location.reload()}
       >
-        <Auth0ProviderWithNavigate>
-          <App />
-        </Auth0ProviderWithNavigate>
+        <DataReloader>
+          <Auth0ProviderWithNavigate>
+            <App />
+          </Auth0ProviderWithNavigate>
+        </DataReloader>
       </ErrorBoundary>
     </BrowserRouter>
     {process.env.REACT_APP_ENV === "development" && <ReactQueryDevtools />}


### PR DESCRIPTION
The current data model has lots of interconnectedness - a field which can be mutated in one mutation can be replicated in several other queries. This creates a problem where a mutation can inadvertently result in stale data in the UI.

To address this - without throwing away the benefits of the local datastore - we introduce a utility to guarantee data consistency: invalidate (or refetch) everything. This can be overridden query-by-query in the API, which should let us migrate them one at a time. The goal here, however, is to ensure that everything remains healthy.