### PR TITLE
chore: Remove plumbed-through access tokens

### DIFF
--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -227,7 +227,6 @@ const Area = () => {
       render: () => (
         <Tab.Pane>
           <ChartGradeDistribution
-            accessToken={accessToken}
             idArea={data[0].id}
             idSector={0}
             data={null}

--- a/src/components/Areas.tsx
+++ b/src/components/Areas.tsx
@@ -12,13 +12,12 @@ import {
 import Leaflet from "./common/leaflet/leaflet";
 import ChartGradeDistribution from "./common/chart-grade-distribution/chart-grade-distribution";
 import { Loading, LockSymbol } from "./common/widgets/widgets";
-import { useAreas, useAccessToken } from "../api";
+import { useAreas } from "../api";
 import { Remarkable } from "remarkable";
 import { linkify } from "remarkable/linkify";
 import { useMeta } from "./common/meta";
 
 const Areas = () => {
-  const accessToken = useAccessToken();
   const { data } = useAreas();
   const meta = useMeta();
   const [flyToId, setFlyToId] = useState<any>(null);
@@ -77,12 +76,7 @@ const Areas = () => {
             <i>{`(${a.numSectors} sectors, ${a.numProblems} ${typeDescription})`}</i>
             <br />
             {a.numProblems > 0 && (
-              <ChartGradeDistribution
-                accessToken={accessToken}
-                idArea={a.id}
-                idSector={0}
-                data={null}
-              />
+              <ChartGradeDistribution idArea={a.id} idSector={0} data={null} />
             )}
             {a.comment && (
               <div

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -1,12 +1,11 @@
 import { Helmet } from "react-helmet";
 import { Header, Segment, Icon } from "semantic-ui-react";
 import { Loading } from "./common/widgets/widgets";
-import { useData, useAccessToken } from "../api";
+import { useData } from "../api";
 import { useMeta } from "./common/meta";
 import ChartGradeDistribution from "./common/chart-grade-distribution/chart-grade-distribution";
 
 const Graph = () => {
-  const accessToken = useAccessToken();
   const meta = useMeta();
   const { data } = useData(`/graph`);
 
@@ -30,12 +29,7 @@ const Graph = () => {
             <Header.Subheader>{description}</Header.Subheader>
           </Header.Content>
         </Header>
-        <ChartGradeDistribution
-          accessToken={accessToken}
-          idArea={0}
-          idSector={0}
-          data={data}
-        />
+        <ChartGradeDistribution idArea={0} idSector={0} data={data} />
       </Segment>
     </>
   );

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -54,7 +54,6 @@ const Profile = () => {
   if (activePage === Page.user) {
     content = (
       <ProfileStatistics
-        accessToken={profile.accessToken}
         userId={profile.id}
         canDownload={loggedInProfile}
         defaultCenter={meta.defaultCenter}
@@ -64,7 +63,6 @@ const Profile = () => {
   } else if (activePage === Page.todo) {
     content = (
       <ProfileTodo
-        accessToken={profile.accessToken}
         userId={profile.id}
         defaultCenter={meta.defaultCenter}
         defaultZoom={meta.defaultZoom}
@@ -73,7 +71,6 @@ const Profile = () => {
   } else if (activePage === Page.media) {
     content = (
       <ProfileMedia
-        accessToken={profile.accessToken}
         userId={profile.id}
         isBouldering={meta.isBouldering}
         captured={false}
@@ -82,19 +79,13 @@ const Profile = () => {
   } else if (activePage === Page.captured) {
     content = (
       <ProfileMedia
-        accessToken={profile.accessToken}
         userId={profile.id}
         isBouldering={meta.isBouldering}
         captured={true}
       />
     );
   } else if (activePage === Page.settings) {
-    content = (
-      <ProfileSettings
-        accessToken={profile.accessToken}
-        userRegions={profile.userRegions}
-      />
-    );
+    content = <ProfileSettings userRegions={profile.userRegions} />;
   }
 
   return (

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -247,12 +247,7 @@ const Sector = () => {
       menuItem: { key: "distribution", icon: "area graph" },
       render: () => (
         <Tab.Pane>
-          <ChartGradeDistribution
-            accessToken={accessToken}
-            idArea={0}
-            idSector={data.id}
-            data={null}
-          />
+          <ChartGradeDistribution idArea={0} idSector={data.id} data={null} />
         </Tab.Pane>
       ),
     });

--- a/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
+++ b/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { Loading } from "../widgets/widgets";
 import { Popup, Table } from "semantic-ui-react";
-import { getGradeDistribution } from "./../../../api";
+import { getGradeDistribution, useAccessToken } from "./../../../api";
 
-const ChartGradeDistribution = ({ accessToken, idArea, idSector, data }) => {
+const ChartGradeDistribution = ({ idArea, idSector, data }) => {
+  const accessToken = useAccessToken();
   const [gradeDistribution, setGradeDistribution] = useState(data ? data : []);
 
   useEffect(() => {

--- a/src/components/common/profile/profile-media.tsx
+++ b/src/components/common/profile/profile-media.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { Loading } from "./../../common/widgets/widgets";
 import { Segment } from "semantic-ui-react";
-import { getProfileMedia } from "../../../api";
+import { getProfileMedia, useAccessToken } from "../../../api";
 import Media from "../../common/media/media";
 
-const ProfileMedia = ({ accessToken, userId, isBouldering, captured }) => {
+const ProfileMedia = ({ userId, isBouldering, captured }) => {
+  const accessToken = useAccessToken();
   const [data, setData] = useState<any[] | null>(null);
   useEffect(() => {
     getProfileMedia(accessToken, userId, captured).then((data) =>

--- a/src/components/common/profile/profile-settings.tsx
+++ b/src/components/common/profile/profile-settings.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Segment, Icon, Label, Header } from "semantic-ui-react";
-import { postUserRegion } from "../../../api";
+import { postUserRegion, useAccessToken } from "../../../api";
 import { useNavigate } from "react-router-dom";
 
-const ProfileSettings = ({ accessToken, userRegions }) => {
+const ProfileSettings = ({ userRegions }) => {
+  const accessToken = useAccessToken();
   const navigate = useNavigate();
   if (!accessToken || !userRegions || userRegions.length === 0) {
     return <Segment>No data</Segment>;

--- a/src/components/common/profile/profile-statistics.tsx
+++ b/src/components/common/profile/profile-statistics.tsx
@@ -9,6 +9,7 @@ import {
   getProfileStatistics,
   numberWithCommas,
   getUsersTicks,
+  useAccessToken,
 } from "../../../api";
 import { saveAs } from "file-saver";
 
@@ -86,7 +87,6 @@ const TickListItem = ({ tick }: TickListItemProps) => (
 );
 
 type ProfileStatisticsProps = {
-  accessToken: string;
   userId: number;
   canDownload: boolean;
   defaultCenter: { lat: number; lng: number };
@@ -94,12 +94,12 @@ type ProfileStatisticsProps = {
 };
 
 const ProfileStatistics = ({
-  accessToken,
   userId,
   canDownload,
   defaultCenter,
   defaultZoom,
 }: ProfileStatisticsProps) => {
+  const accessToken = useAccessToken();
   const [data, setData] =
     useState<Awaited<ReturnType<typeof getProfileStatistics>>>();
   const [isSaving, setIsSaving] = useState(false);

--- a/src/components/common/profile/profile-todo.tsx
+++ b/src/components/common/profile/profile-todo.tsx
@@ -3,21 +3,20 @@ import { Link } from "react-router-dom";
 import Leaflet from "../../common/leaflet/leaflet";
 import { Loading, LockSymbol } from "../../common/widgets/widgets";
 import { List, Segment } from "semantic-ui-react";
-import { getProfileTodo } from "../../../api";
+import { getProfileTodo, useAccessToken } from "../../../api";
 
 type ProfileTodoProps = {
-  accessToken: string;
   userId: number;
   defaultCenter: { lat: number; lng: number };
   defaultZoom: number;
 };
 
 const ProfileTodo = ({
-  accessToken,
   userId,
   defaultCenter,
   defaultZoom,
 }: ProfileTodoProps) => {
+  const accessToken = useAccessToken();
   const [data, setData] =
     useState<Awaited<ReturnType<typeof getProfileTodo>>>();
 


### PR DESCRIPTION
Some components were still using access tokens, provided to them from the outside. This is not necessary, and access tokens can be retrieved locally using the `useAccessToken()` hook.