### PR TITLE
feat: Introduce data-fetching to the profile pages

### DIFF
--- a/src/@types/buldreinfo/index.d.ts
+++ b/src/@types/buldreinfo/index.d.ts
@@ -31,3 +31,53 @@ type Type = {
   type: string;
   subType: string;
 };
+
+type Region = {
+  id: number;
+  name: string;
+  enabled: boolean;
+  readOnly: boolean;
+};
+
+type Profile = {
+  id: number;
+  picture: string;
+  firstname: string;
+  lastname: string;
+  userRegions: Region[];
+};
+
+type Tick = {
+  idProblem: number;
+  dateHr: string;
+  areaName: string;
+  areaLockedAdmin: boolean;
+  areaLockedSuperadmin: boolean;
+  sectorName: string;
+  sectorLockedAdmin: boolean;
+  sectorLockedSuperadmin: boolean;
+  name: string;
+  grade: string;
+  lockedAdmin: boolean;
+  lockedSuperadmin: boolean;
+  stars: number;
+  idTick: number;
+  fa: boolean;
+  idTickRepeat: number;
+  subType: string;
+  numPitches: number;
+  comment: string;
+  lat: number;
+  lng: number;
+  gradeNumber: number;
+  num: number;
+};
+
+type ProfileStatistics = {
+  numImageTags: number;
+  numImagesCreated: number;
+  numVideoTags: number;
+  numVideosCreated: number;
+  orderByGrade: boolean;
+  ticks: Tick[];
+};

--- a/src/api.ts
+++ b/src/api.ts
@@ -109,7 +109,7 @@ export function useData<T = any>(
     transform = (res) => res.json() as Promise<T>,
     ...options
   }: Partial<UseQueryOptions> & {
-    transform?: (response: Awaited<ReturnType<typeof fetch>>) => Promise<any>;
+    transform?: (response: Awaited<ReturnType<typeof fetch>>) => Promise<T>;
   } = {}
 ) {
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
@@ -127,7 +127,11 @@ export function useData<T = any>(
     };
   }
 
-  return useQuery<any>({
+  return useQuery<
+    any, // TQueryFnData
+    unknown, // TError
+    any // TData -- this should be T, but that creates a weird TS error.
+  >({
     queryKey,
     queryFn: async () => {
       const accessToken = isAuthenticated
@@ -568,120 +572,34 @@ export function getProblemEdit(
   }
 }
 
-export function getProfile(
-  accessToken: string | null,
-  id: number
-): Promise<any> {
-  return makeAuthenticatedRequest(accessToken, `/profile?id=${id}`)
-    .then((data) => data.json())
-    .catch((error) => {
-      console.warn(error);
-      return null;
-    });
+export function useProfile(userId: number) {
+  return useData<Profile>(`/profile?id=${userId}`, {
+    queryKey: [`/profile`, { id: userId }],
+  });
 }
 
-export function getProfileMedia(
-  accessToken: string | null,
-  id: number,
-  captured: boolean
-): Promise<any> {
-  return makeAuthenticatedRequest(
-    accessToken,
-    `/profile/media?id=${id}&captured=${captured}`,
-    null
-  )
-    .then((data) => data.json())
-    .catch((error) => {
-      console.warn(error);
-      return null;
-    });
+export function useProfileMedia({
+  userId,
+  captured,
+}: {
+  userId: number;
+  captured: boolean;
+}) {
+  return useData(`/profile/media?id=${userId}&captured=${captured}`, {
+    queryKey: [`/profile/media`, { id: userId, captured }],
+  });
 }
 
-export function getProfileStatistics(
-  accessToken: string | null,
-  id: number
-): Promise<{
-  numImageTags: number;
-  numImagesCreated: number;
-  numVideoTags: number;
-  numVideosCreated: number;
-  orderByGrade: boolean;
-  ticks: {
-    idProblem: number;
-    dateHr: string;
-    areaName: string;
-    areaLockedAdmin: boolean;
-    areaLockedSuperadmin: boolean;
-    sectorName: string;
-    sectorLockedAdmin: boolean;
-    sectorLockedSuperadmin: boolean;
-    name: string;
-    grade: string;
-    lockedAdmin: boolean;
-    lockedSuperadmin: boolean;
-    stars: number;
-    idTick: number;
-    fa: boolean;
-    idTickRepeat: number;
-    subType: string;
-    numPitches: number;
-    comment: string;
-    lat: number;
-    lng: number;
-    gradeNumber: number;
-    num: number;
-  }[];
-}> {
-  return makeAuthenticatedRequest(
-    accessToken,
-    `/profile/statistics?id=${id}`,
-    null
-  )
-    .then((data) => data.json())
-    .catch((error) => {
-      console.warn(error);
-      return null;
-    });
+export function useProfileStatistics(id: number) {
+  return useData<ProfileStatistics>(`/profile/statistics?id=${id}`, {
+    queryKey: [`/profile/statistics`, { id }],
+  });
 }
 
-export function getProfileTodo(
-  accessToken: string | null,
-  id: number
-): Promise<{
-  areas: {
-    name: string;
-    lockedAdmin: boolean;
-    lockedSuperadmin: boolean;
-    url: string;
-    sectors: {
-      name: string;
-      lockedAdmin: boolean;
-      lockedSuperadmin: boolean;
-      url: string;
-      problems: {
-        name: string;
-        lockedAdmin: boolean;
-        lockedSuperadmin: boolean;
-        url: string;
-        nr: number;
-        grade: number;
-        partners?: {
-          name: string;
-          id: string;
-        }[];
-        lat: number;
-        lng: number;
-        id: number;
-      }[];
-    }[];
-  }[];
-}> {
-  return makeAuthenticatedRequest(accessToken, `/profile/todo?id=${id}`)
-    .then((data) => data.json())
-    .catch((error) => {
-      console.warn(error);
-      return null;
-    });
+export function useProfileTodo(id: number) {
+  return useData(`/profile/todo?id=${id}`, {
+    queryKey: [`/profile/todo`, { id }],
+  });
 }
 
 export function useSector(

--- a/src/components/common/profile/profile-media.tsx
+++ b/src/components/common/profile/profile-media.tsx
@@ -1,21 +1,23 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Loading } from "./../../common/widgets/widgets";
 import { Segment } from "semantic-ui-react";
-import { getProfileMedia, useAccessToken } from "../../../api";
+import { useProfileMedia } from "../../../api";
 import Media from "../../common/media/media";
 
-const ProfileMedia = ({ userId, isBouldering, captured }) => {
-  const accessToken = useAccessToken();
-  const [data, setData] = useState<any[] | null>(null);
-  useEffect(() => {
-    getProfileMedia(accessToken, userId, captured).then((data) =>
-      setData(data)
-    );
-  }, [userId, captured, accessToken]);
+type Props = {
+  userId: number;
+  isBouldering: boolean;
+  captured: boolean;
+};
 
-  if (!data) {
+const ProfileMedia = ({ userId, isBouldering, captured }: Props) => {
+  const { data, isLoading } = useProfileMedia({ userId, captured });
+
+  if (isLoading) {
     return <Loading />;
-  } else if (data.length === 0) {
+  }
+
+  if (data.length === 0) {
     return <Segment>Empty list.</Segment>;
   }
 

--- a/src/components/common/profile/profile-statistics.tsx
+++ b/src/components/common/profile/profile-statistics.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import Chart from "../chart/chart";
 import ProblemList from "../problem-list/problem-list";
@@ -6,34 +6,12 @@ import Leaflet from "../../common/leaflet/leaflet";
 import { Loading, LockSymbol, Stars } from "../widgets/widgets";
 import { Icon, List, Label, Divider, Button, Tab } from "semantic-ui-react";
 import {
-  getProfileStatistics,
   numberWithCommas,
   getUsersTicks,
   useAccessToken,
+  useProfileStatistics,
 } from "../../../api";
 import { saveAs } from "file-saver";
-
-type Tick = {
-  idProblem: number;
-  dateHr: string;
-  areaName: string;
-  areaLockedAdmin: boolean;
-  areaLockedSuperadmin: boolean;
-  sectorName: string;
-  sectorLockedAdmin: boolean;
-  sectorLockedSuperadmin: boolean;
-  name: string;
-  grade: string;
-  lockedAdmin: boolean;
-  lockedSuperadmin: boolean;
-  stars: number;
-  idTick: number;
-  fa: boolean;
-  idTickRepeat: number;
-  subType: string;
-  numPitches: number;
-  comment: string;
-};
 
 type TickListItemProps = {
   tick: Tick;
@@ -100,15 +78,10 @@ const ProfileStatistics = ({
   defaultZoom,
 }: ProfileStatisticsProps) => {
   const accessToken = useAccessToken();
-  const [data, setData] =
-    useState<Awaited<ReturnType<typeof getProfileStatistics>>>();
+  const { data, isLoading } = useProfileStatistics(userId);
   const [isSaving, setIsSaving] = useState(false);
 
-  useEffect(() => {
-    getProfileStatistics(accessToken, userId).then((data) => setData(data));
-  }, [accessToken, userId]);
-
-  if (!data) {
+  if (isLoading) {
     return <Loading />;
   }
 

--- a/src/components/common/profile/profile-todo.tsx
+++ b/src/components/common/profile/profile-todo.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import Leaflet from "../../common/leaflet/leaflet";
 import { Loading, LockSymbol } from "../../common/widgets/widgets";
 import { List, Segment } from "semantic-ui-react";
-import { getProfileTodo, useAccessToken } from "../../../api";
+import { useProfileTodo } from "../../../api";
 
 type ProfileTodoProps = {
   userId: number;
@@ -16,17 +16,12 @@ const ProfileTodo = ({
   defaultCenter,
   defaultZoom,
 }: ProfileTodoProps) => {
-  const accessToken = useAccessToken();
-  const [data, setData] =
-    useState<Awaited<ReturnType<typeof getProfileTodo>>>();
-
-  useEffect(() => {
-    getProfileTodo(accessToken, userId).then((data) => setData(data));
-  }, [accessToken, userId]);
+  const { data } = useProfileTodo(userId);
 
   if (!data) {
     return <Loading />;
   }
+
   const markers: NonNullable<React.ComponentProps<typeof Leaflet>["markers"]> =
     [];
   data.areas.forEach((a) => {


### PR DESCRIPTION
Adopt `@tanstack/react-query` throughout the `/profile/*` pages to make the browsing experience better.