### PR TITLE
fix: Only refetch what's necessary for todos

### DIFF
--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -29,7 +29,7 @@ import {
   Feed,
 } from "semantic-ui-react";
 import { useMeta } from "./common/meta";
-import { getImageUrl, getAreaPdfUrl, useAreas, useAccessToken } from "../api";
+import { getImageUrl, getAreaPdfUrl, useAccessToken, useArea } from "../api";
 import { Remarkable } from "remarkable";
 import { linkify } from "remarkable/linkify";
 import ProblemList from "./common/problem-list/problem-list";
@@ -104,7 +104,7 @@ const Area = () => {
   const accessToken = useAccessToken();
   const meta = useMeta();
   const { areaId } = useParams();
-  const { data, error } = useAreas(parseInt(areaId ?? "0"));
+  const { data, error } = useArea(+areaId);
 
   const md = new Remarkable({ breaks: true }).use(linkify);
   // open links in new windows

--- a/src/components/Problem.tsx
+++ b/src/components/Problem.tsx
@@ -31,7 +31,6 @@ import {
   getSectorPdfUrl,
   getProblemPdfUrl,
   postComment,
-  postTodo,
   useProblem,
   useAccessToken,
   useSector,
@@ -206,7 +205,7 @@ const ProblemComments = ({
 }) => {
   const accessToken = useAccessToken();
   const meta = useMeta();
-  const { data } = useProblem(problemId, showHiddenMedia);
+  const { data } = useProblem(+problemId, showHiddenMedia);
 
   function flagAsDangerous({ id, message }) {
     if (confirm("Are you sure you want to flag this comment?")) {
@@ -310,17 +309,10 @@ const Problem = () => {
   const { problemId } = useParams();
   const [showHiddenMedia, setShowHiddenMedia] = useState(false);
   const meta = useMeta();
-  const { data, error } = useProblem(problemId, showHiddenMedia);
+  const { data, error, toggleTodo } = useProblem(+problemId, showHiddenMedia);
 
   const [showTickModal, setShowTickModal] = useState(false);
   const [showCommentModal, setShowCommentModal] = useState<any>(null);
-
-  function toggleTodo(problemId: number) {
-    postTodo(accessToken, problemId).catch((error) => {
-      console.warn(error);
-      alert(error.toString());
-    });
-  }
 
   const onTickModalClose = () => {
     setShowTickModal(false);

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -104,7 +104,7 @@ const Sector = () => {
   const accessToken = useAccessToken();
   const { sectorId } = useParams();
   const meta = useMeta();
-  const { data: data, error, isLoading } = useSector(sectorId);
+  const { data: data, error, isLoading } = useSector(+sectorId);
 
   if (error) {
     return (

--- a/src/components/common/profile/profile-todo.tsx
+++ b/src/components/common/profile/profile-todo.tsx
@@ -11,6 +11,14 @@ type ProfileTodoProps = {
   defaultZoom: number;
 };
 
+const cleanUrl = (url: string) => {
+  const origin = process.env.REACT_APP_API_URL || window.location.origin;
+  if (url.startsWith(origin)) {
+    return url.substring(origin.length);
+  }
+  return url;
+};
+
 const ProfileTodo = ({
   userId,
   defaultCenter,
@@ -41,6 +49,7 @@ const ProfileTodo = ({
   if (data.areas.length === 0) {
     return <Segment>Empty list.</Segment>;
   }
+
   return (
     <Segment>
       <>
@@ -61,50 +70,38 @@ const ProfileTodo = ({
           flyToId={null}
         />
         <List celled>
-          {data.areas.map((area, i) => (
-            <List.Item key={i}>
+          {data.areas.map((area) => (
+            <List.Item key={area.id}>
               <List.Header>
-                <a href={area.url} rel="noreferrer noopener" target="_blank">
-                  {area.name}
-                </a>
+                <Link to={cleanUrl(area.url)}>{area.name}</Link>
                 <LockSymbol
                   lockedAdmin={area.lockedAdmin}
                   lockedSuperadmin={area.lockedSuperadmin}
                 />
               </List.Header>
-              {area.sectors.map((sector, i) => (
-                <List.List key={i}>
+              {area.sectors.map((sector) => (
+                <List.List key={sector.id}>
                   <List.Header>
-                    <a
-                      href={sector.url}
-                      rel="noreferrer noopener"
-                      target="_blank"
-                    >
-                      {sector.name}
-                    </a>
+                    <Link to={cleanUrl(sector.url)}>{sector.name}</Link>
                     <LockSymbol
                       lockedAdmin={sector.lockedAdmin}
                       lockedSuperadmin={sector.lockedSuperadmin}
                     />
                   </List.Header>
                   <List.List>
-                    {sector.problems.map((problem, i) => (
-                      <List.Item key={i}>
+                    {sector.problems.map((problem) => (
+                      <List.Item key={problem.id}>
                         <List.Header>
                           {`#${problem.nr} `}
-                          <a
-                            href={problem.url}
-                            rel="noreferrer noopener"
-                            target="_blank"
-                          >
+                          <Link to={cleanUrl(problem.url)}>
                             {problem.name}
-                          </a>{" "}
+                          </Link>{" "}
                           {problem.grade}
                           {problem.partners && problem.partners.length > 0 && (
                             <small>
                               <i style={{ color: "gray" }}>
                                 {problem.partners.map((u, i) => (
-                                  <React.Fragment key={i}>
+                                  <React.Fragment key={u.id}>
                                     {i === 0 ? " Other users: " : ", "}
                                     <Link to={`/user/${u.id}/todo`}>
                                       {u.name}


### PR DESCRIPTION
When a problem is added (or removed) from a user's to-do list, a few select parts of the data store need to be invalidated & requeried (rather than everything):

 - `/problem` (for the relevant problem)
 - `/sectors` (for the relevant sector)
 - `/areas` (for the relevant area)
 - `/profile/todo` (for the user's to-do list)

This is a slight optimization to the current system, where the entire data model (all previously-fetched data) would be refetched.