### PR TITLE
fix: Odd redirect bug when moving items to trash

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -320,19 +320,6 @@ export function useAreas() {
 export function useArea(id: number) {
   return useData(`/areas?id=${id}`, {
     queryKey: [`/areas`, { id }],
-    transform: (response) => {
-      if (response.status === 500) {
-        return Promise.reject(
-          "Cannot find the specified area because it does not exist or you do not have sufficient permissions."
-        );
-      }
-      return response.json().then((data) => {
-        if (data.redirectUrl && data.redirectUrl != window.location.href) {
-          window.location.href = data.redirectUrl;
-        }
-        return data;
-      });
-    },
   });
 }
 
@@ -456,22 +443,7 @@ export function useProblem(id: number, showHiddenMedia: boolean) {
   const client = useQueryClient();
   const problem = useData(
     `/problem?id=${id}&showHiddenMedia=${showHiddenMedia}`,
-    {
-      queryKey: [`/problem`, { id, showHiddenMedia }],
-      transform: (response) => {
-        if (response.status === 500) {
-          return Promise.reject(
-            "Cannot find the specified problem because it does not exist or you do not have sufficient permissions."
-          );
-        }
-        return response.json().then((data) => {
-          if (data.redirectUrl && data.redirectUrl != window.location.href) {
-            window.location.href = data.redirectUrl;
-          }
-          return data;
-        });
-      },
-    }
+    { queryKey: [`/problem`, { id, showHiddenMedia }] }
   );
 
   const { data: profile } = useProfile(-1);
@@ -655,19 +627,6 @@ export function useSector(
   return useData(`/sectors?id=${id}`, {
     ...(options ?? {}),
     queryKey: [`/sectors`, { id }],
-    transform: (response) => {
-      if (response.status === 500) {
-        return Promise.reject(
-          "Cannot find the specified sector because it does not exist or you do not have sufficient permissions."
-        );
-      }
-      return response.json().then((data) => {
-        if (data.redirectUrl && data.redirectUrl != window.location.href) {
-          window.location.href = data.redirectUrl;
-        }
-        return data;
-      });
-    },
   });
 }
 

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -33,6 +33,7 @@ import { getImageUrl, getAreaPdfUrl, useAccessToken, useArea } from "../api";
 import { Remarkable } from "remarkable";
 import { linkify } from "remarkable/linkify";
 import ProblemList from "./common/problem-list/problem-list";
+import { useRedirect } from "../utils/useRedirect";
 
 const SectorListItem = ({ sector, problem, isClimbing }) => {
   const type = isClimbing
@@ -105,6 +106,7 @@ const Area = () => {
   const meta = useMeta();
   const { areaId } = useParams();
   const { data, error } = useArea(+areaId);
+  const redirecting = useRedirect(data);
 
   const md = new Remarkable({ breaks: true }).use(linkify);
   // open links in new windows
@@ -119,6 +121,10 @@ const Area = () => {
     };
   })();
 
+  if (redirecting) {
+    return redirecting;
+  }
+
   if (error) {
     return (
       <Message
@@ -131,9 +137,12 @@ const Area = () => {
         }
       />
     );
-  } else if (!data || data[0].length === 0) {
+  }
+
+  if (!data || !data?.length) {
     return <Loading />;
   }
+
   const markers = data[0].sectors
     .filter((s) => s.lat != 0 && s.lng != 0)
     .map((s) => {

--- a/src/components/Problem.tsx
+++ b/src/components/Problem.tsx
@@ -38,6 +38,7 @@ import {
 import TickModal from "./common/tick-modal/tick-modal";
 import CommentModal from "./common/comment-modal/comment-modal";
 import Linkify from "react-linkify";
+import { useRedirect } from "../utils/useRedirect";
 
 const componentDecorator = (href, text, key) => (
   <a href={href} key={key} target="_blank" rel="noreferrer">
@@ -310,6 +311,7 @@ const Problem = () => {
   const [showHiddenMedia, setShowHiddenMedia] = useState(false);
   const meta = useMeta();
   const { data, error, toggleTodo } = useProblem(+problemId, showHiddenMedia);
+  const redirecting = useRedirect(data);
 
   const [showTickModal, setShowTickModal] = useState(false);
   const [showCommentModal, setShowCommentModal] = useState<any>(null);
@@ -325,6 +327,10 @@ const Problem = () => {
   const onCommentModalClosed = () => {
     setShowCommentModal(null);
   };
+
+  if (redirecting) {
+    return redirecting;
+  }
 
   if (error) {
     return (

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -37,6 +37,7 @@ import {
   useSector,
 } from "../api";
 import Linkify from "react-linkify";
+import { useRedirect } from "../utils/useRedirect";
 
 const SectorListItem = ({ problem, isClimbing }) => {
   const type = isClimbing
@@ -105,6 +106,11 @@ const Sector = () => {
   const { sectorId } = useParams();
   const meta = useMeta();
   const { data: data, error, isLoading } = useSector(+sectorId);
+  const redirect = useRedirect(data);
+
+  if (redirect) {
+    return redirect;
+  }
 
   if (error) {
     return (
@@ -116,7 +122,9 @@ const Sector = () => {
         content={String(error)}
       />
     );
-  } else if (isLoading || !data || !data.id) {
+  }
+
+  if (isLoading || !data) {
     return <Loading />;
   }
 

--- a/src/utils/useRedirect.tsx
+++ b/src/utils/useRedirect.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Segment } from "semantic-ui-react";
+
+const Redirecting = () => <Segment>Redirecting &hellip;</Segment>;
+
+export const useRedirect = (
+  data: undefined | Record<string, unknown>
+): React.ReactNode | null => {
+  if (!data?.redirectUrl || typeof data?.redirectUrl !== "string") {
+    return null;
+  }
+
+  window.location.href = data.redirectUrl;
+  return <Redirecting />;
+};


### PR DESCRIPTION
When an item (area, sector, problem) was moved to the trash, it kicked off a race condition which would leave the user in an odd state. The sequence of events would look like this:

1. User navigates to `/area/123`
2. User starts to edit the area (`/area/edit/123`)
3. User marks the area for deletion
4. User clicks save
5. A `POST` request is sent to trash the item
6. The user is navigated - with in-app navigation - to the home page (`/`).
7. Under the hood, the `/area/123` query was refetched to keep the data consistent
8. When the response for loading the data comes in, the API layer notices that the server the user should be redirected to `https://.../area/123` and **moves the browser** to the new location
9. The new location (`https://.../area/123`) attempts to load the now-deleted resource, and hangs.

The redirecting now happens at the component level, rather than at the API level. This means that the user won't be blindly redirected just because some possibly-unrelated API call had a side effect.