### PR TITLE
chore: Remove encoded IDs from URLs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -515,12 +515,10 @@ export function getProblem(
 
 export function getProblemEdit(
   accessToken: string | null,
-  sectorIdProblemId: string
+  sectorId: number,
+  problemId: number
 ): Promise<any> {
-  const parts = sectorIdProblemId.split("-");
-  const sectorId = parseInt(parts[0]);
-  const problemId = parseInt(parts[1]);
-  if (problemId === 0) {
+  if (!problemId) {
     return getSector(accessToken, sectorId)
       .then((res) => {
         return {
@@ -653,12 +651,10 @@ export function getSector(
 
 export function getSectorEdit(
   accessToken: string | null,
-  areaIdSectorId: string
+  areaId: number,
+  sectorId: number
 ): Promise<any> {
-  const parts = areaIdSectorId.split("-");
-  const areaId = parseInt(parts[0]);
-  const sectorId = parseInt(parts[1]);
-  if (sectorId === 0) {
+  if (!sectorId) {
     return getArea(accessToken, areaId)
       .then((res) => {
         return {
@@ -724,11 +720,9 @@ export function getSites(
 
 export function getSvgEdit(
   accessToken: string | null,
-  problemIdMediaId: string
+  problemId: number,
+  mediaId: number
 ): Promise<any> {
-  const parts = problemIdMediaId.split("-");
-  const problemId = parts[0];
-  const mediaId = parts[1];
   return makeAuthenticatedRequest(
     accessToken,
     `/problem?id=${problemId}&showHiddenMedia=true`,

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -90,6 +90,10 @@ function AppRoutes() {
           <Route path="/permissions" element={<Permissions />} />
           <Route path="/privacy-policy" element={<PrivacyPolicy />} />
           <Route path="/problem/:problemId" element={<Problem />} />
+          {/*
+            Deprecated. Remove this after July 15 or so - just in case anyone
+            has active sessions or something.
+          */}
           <Route
             path="/problem/edit/:sectorIdProblemId"
             element={<ProblemEdit />}
@@ -99,13 +103,33 @@ function AppRoutes() {
             element={<ProblemEditMedia />}
           />
           <Route
+            path="/problem/edit/:sectorId/:problemId"
+            element={<ProblemEdit />}
+          />
+          {/*
+            Deprecated. Remove this after July 15 or so - just in case anyone
+            has active sessions or something.
+          */}
+          <Route
             path="/problem/svg-edit/:problemIdMediaId"
+            element={<SvgEdit />}
+          />
+          <Route
+            path="/problem/svg-edit/:problemId/:mediaId"
             element={<SvgEdit />}
           />
           <Route path="/problems" element={<Problems />} />
           <Route path="/sites/:type" element={<Sites />} />
           <Route path="/sector/:sectorId" element={<Sector />} />
+          {/*
+            Deprecated. Remove this after July 15 or so - just in case anyone
+            has active sessions or something.
+          */}
           <Route path="/sector/edit/:areaIdSectorId" element={<SectorEdit />} />
+          <Route
+            path="/sector/edit/:areaId/:sectorId"
+            element={<SectorEdit />}
+          />
           <Route path="/ticks/:page" element={<Ticks />} />
           <Route path="/swagger" element={<Swagger />} />
           <Route path="/trash" element={<Trash />} />

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -387,7 +387,7 @@ const Area = () => {
               <Button
                 animated="fade"
                 as={Link}
-                to={`/sector/edit/${data[0].id}-0`}
+                to={`/sector/edit/${data[0].id}/0`}
               >
                 <Button.Content hidden>Add</Button.Content>
                 <Button.Content visible>

--- a/src/components/Problem.tsx
+++ b/src/components/Problem.tsx
@@ -561,7 +561,7 @@ const Problem = () => {
                 <Button
                   animated="fade"
                   as={Link}
-                  to={`/problem/edit/${data.sectorId}-${data.id}`}
+                  to={`/problem/edit/${data.sectorId}/${data.id}`}
                 >
                   <Button.Content hidden>Edit</Button.Content>
                   <Button.Content visible>

--- a/src/components/ProblemEdit.tsx
+++ b/src/components/ProblemEdit.tsx
@@ -25,54 +25,63 @@ import {
   convertFromStringToDate,
   postProblem,
   getSector,
+  useAccessToken,
 } from "../api";
-import { Loading, InsufficientPrivileges } from "./common/widgets/widgets";
-import { useNavigate, useParams, useLocation } from "react-router-dom";
+import {
+  Loading,
+  InsufficientPrivileges,
+  NotLoggedIn,
+} from "./common/widgets/widgets";
+import { useNavigate, useParams } from "react-router-dom";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
+const useIds = (): { sectorId: number; problemId: number } => {
+  const { sectorId, problemId, sectorIdProblemId } = useParams();
+  if (sectorId && problemId) {
+    return { sectorId: +sectorId, problemId: +problemId };
+  }
+  {
+    const [sectorId, problemId] = sectorIdProblemId.split("-").map((v) => +v);
+    return { sectorId, problemId };
+  }
+};
+
 const ProblemEdit = () => {
-  const {
-    isLoading,
-    isAuthenticated,
-    getAccessTokenSilently,
-    loginWithRedirect,
-  } = useAuth0();
+  const accessToken = useAccessToken();
+  const { isAuthenticated } = useAuth0();
+  const { sectorId, problemId } = useIds();
   const [data, setData] = useState<any>(null);
   const [sectorMarkers, setSectorMarkers] = useState([]);
   const [sectorRocks, setSectorRocks] = useState([]);
   const [showSectorMarkers, setShowSectorMarkers] = useState(true);
   const [saving, setSaving] = useState(false);
-  const { sectorIdProblemId } = useParams();
+  const [error, setError] = useState("");
   const navigate = useNavigate();
-  const location = useLocation();
   const meta = useMeta();
   useEffect(() => {
-    if (sectorIdProblemId && isAuthenticated) {
-      getAccessTokenSilently().then((accessToken) => {
-        getProblemEdit(accessToken, sectorIdProblemId).then((data) =>
-          setData({ ...data, accessToken })
-        );
-        const sectorIdProblemIdArray = sectorIdProblemId.split("-");
-        const sectorId = sectorIdProblemIdArray[0];
-        const problemId = sectorIdProblemIdArray[1];
-        getSector(accessToken, parseInt(sectorId)).then((data) => {
-          setSectorMarkers(
-            data.problems
-              .filter((p) => p.lat > 0 && p.lng > 0 && p.id != problemId)
-              .map((p) => ({ lat: p.lat, lng: p.lng, label: p.name }))
-          );
-          setSectorRocks(
-            data.problems
-              .filter((p) => p.rock)
-              .map((p) => p.rock)
-              .filter((value, index, self) => self.indexOf(value) === index)
-              .sort()
-          );
-        });
-      });
+    if (accessToken) {
+      getProblemEdit(accessToken, sectorId, problemId)
+        .then((data) => setData(data))
+        .then(() =>
+          getSector(accessToken, sectorId).then((data) => {
+            setSectorMarkers(
+              data.problems
+                .filter((p) => p.lat > 0 && p.lng > 0 && p.id != problemId)
+                .map((p) => ({ lat: p.lat, lng: p.lng, label: p.name }))
+            );
+            setSectorRocks(
+              data.problems
+                .filter((p) => p.rock)
+                .map((p) => p.rock)
+                .filter((value, index, self) => self.indexOf(value) === index)
+                .sort()
+            );
+          })
+        )
+        .catch((e) => setError(String(e)));
     }
-  }, [getAccessTokenSilently, isAuthenticated, sectorIdProblemId]);
+  }, [accessToken, problemId, sectorId]);
 
   function onNameChanged(e, { value }) {
     setData((prevState) => ({ ...prevState, name: value }));
@@ -260,415 +269,426 @@ const ProblemEdit = () => {
     setData((prevState) => ({ ...prevState, sections }));
   }
 
-  if (isLoading || (isAuthenticated && !data?.sectorId)) {
-    return <Loading />;
-  } else if (!isAuthenticated) {
-    loginWithRedirect({ appState: { returnTo: location.pathname } });
-  } else if (!meta.isAdmin) {
+  if (!isAuthenticated) {
+    return <NotLoggedIn />;
+  }
+
+  if (!meta.isAdmin) {
     return <InsufficientPrivileges />;
-  } else {
-    let defaultCenter;
-    let defaultZoom: number;
-    if (data.lat != 0 && data.lng != 0) {
-      defaultCenter = { lat: data.lat, lng: data.lng };
-      defaultZoom = 15;
-    } else {
-      defaultCenter = meta.defaultCenter;
-      defaultZoom = meta.defaultZoom;
-    }
-    const lockedOptions = [
-      { key: 0, value: 0, text: "Visible for everyone" },
-      { key: 1, value: 1, text: "Only visible for administrators" },
-    ];
-    if (meta.isSuperAdmin) {
-      lockedOptions.push({
-        key: 2,
-        value: 2,
-        text: "Only visible for super administrators",
-      });
-    }
-    let lockedValue = 0;
-    if (data.lockedSuperadmin) {
-      lockedValue = 2;
-    } else if (data.lockedAdmin) {
-      lockedValue = 1;
-    }
+  }
 
-    const markers = [];
-    if (data.lat != 0 && data.lng != 0) {
-      markers.push({ lat: data.lat, lng: data.lng });
-    }
-    if (showSectorMarkers && sectorMarkers) {
-      markers.push(...sectorMarkers);
-    }
-
-    const sectorId = sectorIdProblemId.split("-")[0];
-    const problemId = sectorIdProblemId.split("-")[1];
-
+  if (error) {
     return (
-      <>
-        <Helmet>
-          <title>
-            Edit {data.name} | {meta.title}
-          </title>
-        </Helmet>
-        <Message
-          size="tiny"
-          content={
-            <>
-              <Icon name="info" />
-              Contact{" "}
-              <a href="mailto:jostein.oygarden@gmail.com">
-                Jostein Øygarden
-              </a>{" "}
-              if you want to move {meta.isBouldering ? "problem" : "route"} to
-              an other sector.
-            </>
-          }
-        />
-        <Form>
-          <Segment>
-            <Form.Group widths="equal">
-              <Form.Field
-                label="Name"
-                control={Input}
-                placeholder="Enter name"
-                value={data.name}
-                onChange={onNameChanged}
-                error={data.name ? false : "Name required"}
-              />
-              <Form.Field
-                label="Visibility"
-                control={Dropdown}
-                selection
-                value={lockedValue}
-                onChange={onLockedChanged}
-                options={lockedOptions}
-              />
-              <Form.Field
-                label="Number"
-                control={Input}
-                placeholder="Enter number"
-                value={data.nr}
-                onChange={onNrChanged}
-              />
-              <Form.Field>
-                <label>Move to trash</label>
-                <Checkbox
-                  disabled={!data.id || data.id <= 0}
-                  toggle
-                  checked={data.trash}
-                  onChange={() =>
-                    setData((prevState) => ({
-                      ...prevState,
-                      trash: !data.trash,
-                    }))
-                  }
-                />
-              </Form.Field>
-            </Form.Group>
-            <Form.Group widths="equal">
-              <Form.Field
-                label="Grade"
-                control={Dropdown}
-                selection
-                value={data.originalGrade}
-                onChange={onOriginalGradeChanged}
-                options={meta.grades.map((g, i) => ({
-                  key: i,
-                  value: g.grade,
-                  text: g.grade,
-                }))}
-                error={data.originalGrade ? false : "grade required"}
-              />
-              <Form.Field
-                label="FA User(s)"
-                control={UserSelector}
-                isMulti={true}
-                placeholder="Select user(s)"
-                users={
-                  data.fa
-                    ? data.fa.map((u) => {
-                        return { value: u.id, label: u.name };
-                      })
-                    : []
-                }
-                onUsersUpdated={onUsersUpdated}
-                identity={null}
-              />
-              <Form.Field>
-                <label>FA Date</label>
-                <DatePicker
-                  placeholderText="Click to select a date"
-                  dateFormat="dd-MM-yyyy"
-                  showMonthDropdown
-                  showYearDropdown
-                  dropdownMode="select"
-                  selected={convertFromStringToDate(data.faDate)}
-                  onChange={(date) => onFaDateChanged(date)}
-                />
-              </Form.Field>
-              {meta.isBouldering ? (
-                <Form.Field
-                  label="Rock (this field is optional, use to group boulders by rock in sector)"
-                  control={RockSelector}
-                  placeholder="Add rock"
-                  rock={data.rock}
-                  onRockUpdated={onRockChanged}
-                  rocks={sectorRocks}
-                  identity={null}
-                />
-              ) : (
-                <Form.Field />
-              )}
-            </Form.Group>
-            <Form.Field
-              label="Description"
-              control={TextArea}
-              placeholder="Enter description"
-              style={{ minHeight: 100 }}
-              value={data.comment}
-              onChange={onCommentChanged}
-            />
-            <Form.Field
-              label="Trivia (e.g. name origin)"
-              control={TextArea}
-              placeholder="Enter trivia"
-              style={{ minHeight: 100 }}
-              value={data.trivia}
-              onChange={onTriviaChanged}
-            />
-            {meta.isIce && (
-              <>
-                <Form.Field
-                  label="Starting altitude"
-                  control={Input}
-                  placeholder="Enter starting altitude"
-                  value={data.startingAltitude}
-                  onChange={onStartingAltitudeChanged}
-                />
-                <Form.Field
-                  label="Aspect"
-                  control={Input}
-                  placeholder="Enter aspect"
-                  value={data.aspect}
-                  onChange={onAspectChanged}
-                />
-                <Form.Field
-                  label="Route length"
-                  control={Input}
-                  placeholder="Enter route length"
-                  value={data.routeLength}
-                  onChange={onRouteLengthChanged}
-                />
-                <Form.Field
-                  label="Descent"
-                  control={Input}
-                  placeholder="Enter descent"
-                  value={data.descent}
-                  onChange={onDescentChanged}
-                />
-              </>
-            )}
-          </Segment>
-
-          <Segment>
-            <Form.Field>
-              <label>Upload image(s) or embed video(s)</label>
-              <br />
-              <ImageUpload
-                onMediaChanged={onNewMediaChanged}
-                isMultiPitch={data.sections && data.sections.length > 1}
-                includeVideoEmbedder={true}
-              />
-            </Form.Field>
-          </Segment>
-
-          {meta.isClimbing && (
-            <Segment>
-              <Form.Field
-                label="Type"
-                control={Dropdown}
-                selection
-                value={data.typeId}
-                onChange={onTypeIdChanged}
-                options={meta.types.map((t, i) => {
-                  const text = t.type + (t.subType ? " - " + t.subType : "");
-                  return { key: i, value: t.id, text: text };
-                })}
-                error={data.typeId ? false : "Type required"}
-              ></Form.Field>
-              <Form.Field>
-                <label>First AID ascent?</label>
-                <Button.Group size="tiny">
-                  <Button
-                    onClick={() =>
-                      setData((prevState) => ({
-                        ...prevState,
-                        faAid: {
-                          problemId: data.id,
-                          date: "",
-                          description: "",
-                        },
-                      }))
-                    }
-                    positive={data.faAid ? true : false}
-                  >
-                    Yes
-                  </Button>
-                  <Button.Or />
-                  <Button
-                    onClick={() =>
-                      setData((prevState) => ({ ...prevState, faAid: null }))
-                    }
-                    positive={data.faAid ? false : true}
-                  >
-                    No
-                  </Button>
-                </Button.Group>
-                {data.faAid && (
-                  <Container>
-                    <DatePicker
-                      placeholderText="Click to select a date"
-                      dateFormat="dd-MM-yyyy"
-                      withPortal
-                      portalId="root-portal"
-                      showMonthDropdown
-                      showYearDropdown
-                      dropdownMode="select"
-                      selected={convertFromStringToDate(
-                        data.faAid ? data.faAid.date : ""
-                      )}
-                      onChange={(date) => onFaAidDateChanged(date)}
-                    />
-                    <TextArea
-                      placeholder="Enter description"
-                      style={{ minHeight: 75 }}
-                      value={data.faAid.description}
-                      onChange={onFaAidDescriptionChanged}
-                    />
-                    <UserSelector
-                      isMulti={true}
-                      placeholder="Select user(s)"
-                      users={
-                        data.faAid.users
-                          ? data.faAid.users.map((u) => {
-                              return { value: u.id, label: u.name };
-                            })
-                          : []
-                      }
-                      onUsersUpdated={onFaAidUsersUpdated}
-                      identity={null}
-                    />
-                  </Container>
-                )}
-              </Form.Field>
-              <Form.Field>
-                <label>Pitches</label>
-                <ProblemSection
-                  sections={data.sections}
-                  grades={meta.grades}
-                  onSectionsUpdated={onSectionsUpdated}
-                />
-              </Form.Field>
-            </Segment>
-          )}
-
-          <Segment>
-            <Form.Field>
-              <label>Click to mark problem on map</label>
-              <Leaflet
-                autoZoom={true}
-                markers={markers}
-                defaultCenter={defaultCenter}
-                defaultZoom={defaultZoom}
-                onMouseClick={onMapClick}
-                onMouseMove={null}
-                polylines={null}
-                outlines={null}
-                height={"300px"}
-                showSateliteImage={true}
-                clusterMarkers={false}
-                rocks={null}
-                flyToId={null}
-              />
-            </Form.Field>
-            <Form.Group widths="equal">
-              <Form.Field>
-                <label>Latitude</label>
-                <Input
-                  placeholder="Latitude"
-                  value={data.latStr}
-                  onChange={onLatChanged}
-                />
-              </Form.Field>
-              <Form.Field>
-                <label>Longitude</label>
-                <Input
-                  placeholder="Longitude"
-                  value={data.lngStr}
-                  onChange={onLngChanged}
-                />
-              </Form.Field>
-              <Form.Field>
-                <label>Include all markers in sector</label>
-                <Checkbox
-                  toggle
-                  checked={showSectorMarkers}
-                  onChange={(e, d) => {
-                    if (d.checked) {
-                      setShowSectorMarkers(true);
-                    } else {
-                      setShowSectorMarkers(false);
-                    }
-                  }}
-                />
-              </Form.Field>
-            </Form.Group>
-          </Segment>
-
-          <Button.Group>
-            <Button
-              negative
-              onClick={() => {
-                if (problemId && problemId != "0") {
-                  navigate(`/problem/${problemId}`);
-                } else {
-                  navigate(`/sector/${sectorId}`);
-                }
-              }}
-            >
-              Cancel
-            </Button>
-            <Button.Or />
-            <Button
-              positive
-              loading={saving}
-              onClick={(event) => save(event, false)}
-              disabled={!data.name || (meta.types.length > 1 && !data.typeId)}
-            >
-              Save
-            </Button>
-            {problemId === "0" && (
-              <>
-                <Button.Or />
-                <Button
-                  positive
-                  loading={saving}
-                  onClick={(event) => save(event, true)}
-                  disabled={
-                    !data.name || (meta.types.length > 1 && !data.typeId)
-                  }
-                >
-                  Save, and add new
-                </Button>
-              </>
-            )}
-          </Button.Group>
-        </Form>
-      </>
+      <Message
+        size="huge"
+        style={{ backgroundColor: "#FFF" }}
+        icon="meh"
+        header="404"
+        content={
+          "Cannot find the specified problem because it does not exist or you do not have sufficient permissions."
+        }
+      />
     );
   }
+
+  if (!data) {
+    return <Loading />;
+  }
+
+  let defaultCenter;
+  let defaultZoom: number;
+  if (data.lat != 0 && data.lng != 0) {
+    defaultCenter = { lat: data.lat, lng: data.lng };
+    defaultZoom = 15;
+  } else {
+    defaultCenter = meta.defaultCenter;
+    defaultZoom = meta.defaultZoom;
+  }
+  const lockedOptions = [
+    { key: 0, value: 0, text: "Visible for everyone" },
+    { key: 1, value: 1, text: "Only visible for administrators" },
+  ];
+  if (meta.isSuperAdmin) {
+    lockedOptions.push({
+      key: 2,
+      value: 2,
+      text: "Only visible for super administrators",
+    });
+  }
+  let lockedValue = 0;
+  if (data.lockedSuperadmin) {
+    lockedValue = 2;
+  } else if (data.lockedAdmin) {
+    lockedValue = 1;
+  }
+
+  const markers = [];
+  if (data.lat != 0 && data.lng != 0) {
+    markers.push({ lat: data.lat, lng: data.lng });
+  }
+  if (showSectorMarkers && sectorMarkers) {
+    markers.push(...sectorMarkers);
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>
+          Edit {data.name} | {meta.title}
+        </title>
+      </Helmet>
+      <Message
+        size="tiny"
+        content={
+          <>
+            <Icon name="info" />
+            Contact{" "}
+            <a href="mailto:jostein.oygarden@gmail.com">Jostein Øygarden</a> if
+            you want to move {meta.isBouldering ? "problem" : "route"} to an
+            other sector.
+          </>
+        }
+      />
+      <Form>
+        <Segment>
+          <Form.Group widths="equal">
+            <Form.Field
+              label="Name"
+              control={Input}
+              placeholder="Enter name"
+              value={data.name}
+              onChange={onNameChanged}
+              error={data.name ? false : "Name required"}
+            />
+            <Form.Field
+              label="Visibility"
+              control={Dropdown}
+              selection
+              value={lockedValue}
+              onChange={onLockedChanged}
+              options={lockedOptions}
+            />
+            <Form.Field
+              label="Number"
+              control={Input}
+              placeholder="Enter number"
+              value={data.nr}
+              onChange={onNrChanged}
+            />
+            <Form.Field>
+              <label>Move to trash</label>
+              <Checkbox
+                disabled={!data.id || data.id <= 0}
+                toggle
+                checked={data.trash}
+                onChange={() =>
+                  setData((prevState) => ({
+                    ...prevState,
+                    trash: !data.trash,
+                  }))
+                }
+              />
+            </Form.Field>
+          </Form.Group>
+          <Form.Group widths="equal">
+            <Form.Field
+              label="Grade"
+              control={Dropdown}
+              selection
+              value={data.originalGrade}
+              onChange={onOriginalGradeChanged}
+              options={meta.grades.map((g, i) => ({
+                key: i,
+                value: g.grade,
+                text: g.grade,
+              }))}
+              error={data.originalGrade ? false : "grade required"}
+            />
+            <Form.Field
+              label="FA User(s)"
+              control={UserSelector}
+              isMulti={true}
+              placeholder="Select user(s)"
+              users={
+                data.fa
+                  ? data.fa.map((u) => {
+                      return { value: u.id, label: u.name };
+                    })
+                  : []
+              }
+              onUsersUpdated={onUsersUpdated}
+              identity={null}
+            />
+            <Form.Field>
+              <label>FA Date</label>
+              <DatePicker
+                placeholderText="Click to select a date"
+                dateFormat="dd-MM-yyyy"
+                showMonthDropdown
+                showYearDropdown
+                dropdownMode="select"
+                selected={convertFromStringToDate(data.faDate)}
+                onChange={(date) => onFaDateChanged(date)}
+              />
+            </Form.Field>
+            {meta.isBouldering ? (
+              <Form.Field
+                label="Rock (this field is optional, use to group boulders by rock in sector)"
+                control={RockSelector}
+                placeholder="Add rock"
+                rock={data.rock}
+                onRockUpdated={onRockChanged}
+                rocks={sectorRocks}
+                identity={null}
+              />
+            ) : (
+              <Form.Field />
+            )}
+          </Form.Group>
+          <Form.Field
+            label="Description"
+            control={TextArea}
+            placeholder="Enter description"
+            style={{ minHeight: 100 }}
+            value={data.comment}
+            onChange={onCommentChanged}
+          />
+          <Form.Field
+            label="Trivia (e.g. name origin)"
+            control={TextArea}
+            placeholder="Enter trivia"
+            style={{ minHeight: 100 }}
+            value={data.trivia}
+            onChange={onTriviaChanged}
+          />
+          {meta.isIce && (
+            <>
+              <Form.Field
+                label="Starting altitude"
+                control={Input}
+                placeholder="Enter starting altitude"
+                value={data.startingAltitude}
+                onChange={onStartingAltitudeChanged}
+              />
+              <Form.Field
+                label="Aspect"
+                control={Input}
+                placeholder="Enter aspect"
+                value={data.aspect}
+                onChange={onAspectChanged}
+              />
+              <Form.Field
+                label="Route length"
+                control={Input}
+                placeholder="Enter route length"
+                value={data.routeLength}
+                onChange={onRouteLengthChanged}
+              />
+              <Form.Field
+                label="Descent"
+                control={Input}
+                placeholder="Enter descent"
+                value={data.descent}
+                onChange={onDescentChanged}
+              />
+            </>
+          )}
+        </Segment>
+
+        <Segment>
+          <Form.Field>
+            <label>Upload image(s) or embed video(s)</label>
+            <br />
+            <ImageUpload
+              onMediaChanged={onNewMediaChanged}
+              isMultiPitch={data.sections && data.sections.length > 1}
+              includeVideoEmbedder={true}
+            />
+          </Form.Field>
+        </Segment>
+
+        {meta.isClimbing && (
+          <Segment>
+            <Form.Field
+              label="Type"
+              control={Dropdown}
+              selection
+              value={data.typeId}
+              onChange={onTypeIdChanged}
+              options={meta.types.map((t, i) => {
+                const text = t.type + (t.subType ? " - " + t.subType : "");
+                return { key: i, value: t.id, text: text };
+              })}
+              error={data.typeId ? false : "Type required"}
+            />
+            <Form.Field>
+              <label>First AID ascent?</label>
+              <Button.Group size="tiny">
+                <Button
+                  onClick={() =>
+                    setData((prevState) => ({
+                      ...prevState,
+                      faAid: {
+                        problemId: data.id,
+                        date: "",
+                        description: "",
+                      },
+                    }))
+                  }
+                  positive={data.faAid ? true : false}
+                >
+                  Yes
+                </Button>
+                <Button.Or />
+                <Button
+                  onClick={() =>
+                    setData((prevState) => ({ ...prevState, faAid: null }))
+                  }
+                  positive={data.faAid ? false : true}
+                >
+                  No
+                </Button>
+              </Button.Group>
+              {data.faAid && (
+                <Container>
+                  <DatePicker
+                    placeholderText="Click to select a date"
+                    dateFormat="dd-MM-yyyy"
+                    withPortal
+                    portalId="root-portal"
+                    showMonthDropdown
+                    showYearDropdown
+                    dropdownMode="select"
+                    selected={convertFromStringToDate(
+                      data.faAid ? data.faAid.date : ""
+                    )}
+                    onChange={(date) => onFaAidDateChanged(date)}
+                  />
+                  <TextArea
+                    placeholder="Enter description"
+                    style={{ minHeight: 75 }}
+                    value={data.faAid.description}
+                    onChange={onFaAidDescriptionChanged}
+                  />
+                  <UserSelector
+                    isMulti={true}
+                    placeholder="Select user(s)"
+                    users={
+                      data.faAid.users
+                        ? data.faAid.users.map((u) => {
+                            return { value: u.id, label: u.name };
+                          })
+                        : []
+                    }
+                    onUsersUpdated={onFaAidUsersUpdated}
+                    identity={null}
+                  />
+                </Container>
+              )}
+            </Form.Field>
+            <Form.Field>
+              <label>Pitches</label>
+              <ProblemSection
+                sections={data.sections}
+                grades={meta.grades}
+                onSectionsUpdated={onSectionsUpdated}
+              />
+            </Form.Field>
+          </Segment>
+        )}
+
+        <Segment>
+          <Form.Field>
+            <label>Click to mark problem on map</label>
+            <Leaflet
+              autoZoom={true}
+              markers={markers}
+              defaultCenter={defaultCenter}
+              defaultZoom={defaultZoom}
+              onMouseClick={onMapClick}
+              onMouseMove={null}
+              polylines={null}
+              outlines={null}
+              height={"300px"}
+              showSateliteImage={true}
+              clusterMarkers={false}
+              rocks={null}
+              flyToId={null}
+            />
+          </Form.Field>
+          <Form.Group widths="equal">
+            <Form.Field>
+              <label>Latitude</label>
+              <Input
+                placeholder="Latitude"
+                value={data.latStr}
+                onChange={onLatChanged}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Longitude</label>
+              <Input
+                placeholder="Longitude"
+                value={data.lngStr}
+                onChange={onLngChanged}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Include all markers in sector</label>
+              <Checkbox
+                toggle
+                checked={showSectorMarkers}
+                onChange={(e, d) => {
+                  if (d.checked) {
+                    setShowSectorMarkers(true);
+                  } else {
+                    setShowSectorMarkers(false);
+                  }
+                }}
+              />
+            </Form.Field>
+          </Form.Group>
+        </Segment>
+
+        <Button.Group>
+          <Button
+            negative
+            onClick={() => {
+              if (problemId && !!problemId) {
+                navigate(`/problem/${problemId}`);
+              } else {
+                navigate(`/sector/${sectorId}`);
+              }
+            }}
+          >
+            Cancel
+          </Button>
+          <Button.Or />
+          <Button
+            positive
+            loading={saving}
+            onClick={(event) => save(event, false)}
+            disabled={!data.name || (meta.types.length > 1 && !data.typeId)}
+          >
+            Save
+          </Button>
+          {!problemId && (
+            <>
+              <Button.Or />
+              <Button
+                positive
+                loading={saving}
+                onClick={(event) => save(event, true)}
+                disabled={!data.name || (meta.types.length > 1 && !data.typeId)}
+              >
+                Save, and add new
+              </Button>
+            </>
+          )}
+        </Button.Group>
+      </Form>
+    </>
+  );
 };
 
 export default ProblemEdit;

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -331,7 +331,7 @@ const Sector = () => {
               <Button
                 animated="fade"
                 as={Link}
-                to={`/problem/edit/${data.id}-0`}
+                to={`/problem/edit/${data.id}/0`}
               >
                 <Button.Content hidden>Add</Button.Content>
                 <Button.Content visible>
@@ -341,7 +341,7 @@ const Sector = () => {
               <Button
                 animated="fade"
                 as={Link}
-                to={`/sector/edit/${data.areaId}-${data.id}`}
+                to={`/sector/edit/${data.areaId}/${data.id}`}
               >
                 <Button.Content hidden>Edit</Button.Content>
                 <Button.Content visible>

--- a/src/components/SvgEdit.tsx
+++ b/src/components/SvgEdit.tsx
@@ -2,7 +2,12 @@ import React, { useState, useEffect, useRef } from "react";
 import { Container, Button, Segment, Dropdown, Input } from "semantic-ui-react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useMeta } from "./common/meta";
-import { getSvgEdit, getImageUrl, postProblemSvg } from "../api";
+import {
+  getSvgEdit,
+  getImageUrl,
+  postProblemSvg,
+  useAccessToken,
+} from "../api";
 import { parseReadOnlySvgs, parsePath } from "../utils/svg-utils";
 import {
   Loading,
@@ -11,10 +16,22 @@ import {
 } from "./common/widgets/widgets";
 import { useNavigate, useParams } from "react-router-dom";
 
+const useIds = (): { problemId: number; mediaId: number } => {
+  const { mediaId, problemId, problemIdMediaId } = useParams();
+  if (mediaId && problemId) {
+    return { mediaId: +mediaId, problemId: +problemId };
+  }
+  {
+    const [problemId, mediaId] = problemIdMediaId.split("-").map((v) => +v);
+    return { problemId, mediaId };
+  }
+};
+
 const SvgEdit = () => {
+  const accessToken = useAccessToken();
+  const { problemId, mediaId } = useIds();
   const [saving, setSaving] = useState(false);
-  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const [mediaId, setMediaId] = useState<any>(null);
+  const { isAuthenticated } = useAuth0();
   const [crc32, setCrc32] = useState<any>(null);
   const [w, setW] = useState<any>(null);
   const [h, setH] = useState<any>(null);
@@ -35,42 +52,40 @@ const SvgEdit = () => {
   const [addAnchor, setAddAnchor] = useState(false);
   const [addText, setAddText] = useState(false);
   const imageRef = useRef<SVGImageElement>(null);
-  const { problemIdMediaId } = useParams();
   const navigate = useNavigate();
   const { outerWidth, outerHeight } = window;
   const minWindowScale = Math.min(outerWidth, outerHeight);
   const black = "#000000";
   const meta = useMeta();
+
   useEffect(() => {
-    if (problemIdMediaId && isAuthenticated) {
-      getAccessTokenSilently().then((accessToken) => {
-        getSvgEdit(accessToken, problemIdMediaId).then((data) => {
-          setMediaId(data.mediaId);
-          setCrc32(data.crc32);
-          setW(data.w);
-          setH(data.h);
-          setShift(data.shift);
-          setSvgId(data.svgId);
-          const correctPoints = parsePath(data.path);
-          const correctPathTxt = generatePath(correctPoints);
-          setPath(correctPathTxt);
-          setPathTxt(correctPathTxt);
-          setPoints(correctPoints);
-          setAnchors(data.anchors);
-          setTexts(data.texts);
-          setReadOnlySvgs(data.readOnlySvgs);
-          setReadOnlyPoints(
-            data.readOnlySvgs?.map((svg) => parsePath(svg.path)).flat()
-          );
-          setActivePoint(data.activePoint);
-          setDraggedPoint(data.draggedPoint);
-          setDraggedCubic(data.draggedCubic);
-          setHasAnchor(data.hasAnchor);
-          setId(data.id);
-        });
+    if (accessToken) {
+      getSvgEdit(accessToken, problemId, mediaId).then((data) => {
+        setCrc32(data.crc32);
+        setW(data.w);
+        setH(data.h);
+        setShift(data.shift);
+        setSvgId(data.svgId);
+        const correctPoints = parsePath(data.path);
+        const correctPathTxt = generatePath(correctPoints);
+        setPath(correctPathTxt);
+        setPathTxt(correctPathTxt);
+        setPoints(correctPoints);
+        setAnchors(data.anchors);
+        setTexts(data.texts);
+        setReadOnlySvgs(data.readOnlySvgs);
+        setReadOnlyPoints(
+          data.readOnlySvgs?.map((svg) => parsePath(svg.path)).flat()
+        );
+        setActivePoint(data.activePoint);
+        setDraggedPoint(data.draggedPoint);
+        setDraggedCubic(data.draggedCubic);
+        setHasAnchor(data.hasAnchor);
+        setId(data.id);
       });
     }
-  }, [getAccessTokenSilently, isAuthenticated, problemIdMediaId]);
+  }, [accessToken, mediaId, problemId]);
+
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);
@@ -101,25 +116,23 @@ const SvgEdit = () => {
   function save(event) {
     event.preventDefault();
     setSaving(true);
-    getAccessTokenSilently().then((accessToken) => {
-      postProblemSvg(
-        accessToken,
-        id,
-        mediaId,
-        points.length < 2,
-        svgId,
-        path,
-        hasAnchor,
-        JSON.stringify(anchors),
-        JSON.stringify(texts)
-      )
-        .then(() => {
-          navigate(`/problem/${id}`);
-        })
-        .catch((error) => {
-          console.warn(error);
-        });
-    });
+    postProblemSvg(
+      accessToken,
+      id,
+      mediaId,
+      points.length < 2,
+      svgId,
+      path,
+      hasAnchor,
+      JSON.stringify(anchors),
+      JSON.stringify(texts)
+    )
+      .then(() => {
+        navigate(`/problem/${id}`);
+      })
+      .catch((error) => {
+        console.warn(error);
+      });
   }
 
   function cancelDragging() {
@@ -327,277 +340,272 @@ const SvgEdit = () => {
     setHasAnchor(true);
   }
 
-  if (isLoading || (isAuthenticated && !mediaId)) {
-    return <Loading />;
-  } else if (!isAuthenticated) {
+  if (!isAuthenticated) {
     return <NotLoggedIn />;
-  } else if (!meta.isAdmin) {
-    return <InsufficientPrivileges />;
-  } else if (!id || !meta) {
-    return <Loading />;
-  } else {
-    const circles = points.map((p, i, a) => {
-      const anchors: JSX.Element[] = [];
-      if (p.c) {
-        const stroke = "#FFFFFF";
-        anchors.push(
-          <g key={anchors.length} className="buldreinfo-svg-edit-opacity">
-            <line
-              className={"buldreinfo-svg-pointer"}
-              style={{ fill: "none", stroke: black }}
-              x1={a[i - 1].x}
-              y1={a[i - 1].y}
-              x2={p.c[0].x}
-              y2={p.c[0].y}
-              strokeWidth={0.003 * w}
-              strokeDasharray={0.003 * w}
-            />
-            <line
-              className={"buldreinfo-svg-pointer"}
-              style={{ fill: "none", stroke: black }}
-              x1={p.x}
-              y1={p.y}
-              x2={p.c[1].x}
-              y2={p.c[1].y}
-              strokeWidth={0.003 * w}
-              strokeDasharray={0.003 * w}
-            />
-            <circle
-              className={"buldreinfo-svg-pointer"}
-              fill={black}
-              cx={p.c[0].x}
-              cy={p.c[0].y}
-              r={0.003 * w}
-              onMouseDown={() => setCurrDraggedCubic(i, 0)}
-            />
-            <circle
-              className={"buldreinfo-svg-pointer"}
-              fill={black}
-              cx={p.c[1].x}
-              cy={p.c[1].y}
-              r={0.003 * w}
-              onMouseDown={() => setCurrDraggedCubic(i, 1)}
-            />
+  }
 
-            <line
-              className={"buldreinfo-svg-pointer"}
-              style={{ fill: "none", stroke: stroke }}
-              x1={a[i - 1].x}
-              y1={a[i - 1].y}
-              x2={p.c[0].x}
-              y2={p.c[0].y}
-              strokeWidth={0.0015 * w}
-              strokeDasharray={0.003 * w}
-            />
-            <line
-              className={"buldreinfo-svg-pointer"}
-              style={{ fill: "none", stroke: stroke }}
-              x1={p.x}
-              y1={p.y}
-              x2={p.c[1].x}
-              y2={p.c[1].y}
-              strokeWidth={0.0015 * w}
-              strokeDasharray={0.003 * w}
-            />
-            <circle
-              className={"buldreinfo-svg-pointer"}
-              fill={stroke}
-              cx={p.c[0].x}
-              cy={p.c[0].y}
-              r={0.002 * w}
-              onMouseDown={() => setCurrDraggedCubic(i, 0)}
-            />
-            <circle
-              className={"buldreinfo-svg-pointer"}
-              fill={stroke}
-              cx={p.c[1].x}
-              cy={p.c[1].y}
-              r={0.002 * w}
-              onMouseDown={() => setCurrDraggedCubic(i, 1)}
-            />
-          </g>
-        );
-      }
-      const fill = activePoint === i ? "#00FF00" : "#FF0000";
-      return (
-        <g key={i}>
-          {anchors}
+  if (!meta.isAdmin) {
+    return <InsufficientPrivileges />;
+  }
+
+  if (!id || !meta) {
+    return <Loading />;
+  }
+
+  const circles = points.map((p, i, a) => {
+    const anchors: JSX.Element[] = [];
+    if (p.c) {
+      const stroke = "#FFFFFF";
+      anchors.push(
+        <g key={anchors.length} className="buldreinfo-svg-edit-opacity">
+          <line
+            className={"buldreinfo-svg-pointer"}
+            style={{ fill: "none", stroke: black }}
+            x1={a[i - 1].x}
+            y1={a[i - 1].y}
+            x2={p.c[0].x}
+            y2={p.c[0].y}
+            strokeWidth={0.003 * w}
+            strokeDasharray={0.003 * w}
+          />
+          <line
+            className={"buldreinfo-svg-pointer"}
+            style={{ fill: "none", stroke: black }}
+            x1={p.x}
+            y1={p.y}
+            x2={p.c[1].x}
+            y2={p.c[1].y}
+            strokeWidth={0.003 * w}
+            strokeDasharray={0.003 * w}
+          />
           <circle
             className={"buldreinfo-svg-pointer"}
             fill={black}
-            cx={p.x}
-            cy={p.y}
-            r={0.004 * w}
-            onMouseDown={() => setCurrDraggedPoint(i)}
+            cx={p.c[0].x}
+            cy={p.c[0].y}
+            r={0.003 * w}
+            onMouseDown={() => setCurrDraggedCubic(i, 0)}
           />
           <circle
             className={"buldreinfo-svg-pointer"}
-            fill={fill}
-            cx={p.x}
-            cy={p.y}
+            fill={black}
+            cx={p.c[1].x}
+            cy={p.c[1].y}
             r={0.003 * w}
-            onMouseDown={() => setCurrDraggedPoint(i)}
+            onMouseDown={() => setCurrDraggedCubic(i, 1)}
+          />
+
+          <line
+            className={"buldreinfo-svg-pointer"}
+            style={{ fill: "none", stroke: stroke }}
+            x1={a[i - 1].x}
+            y1={a[i - 1].y}
+            x2={p.c[0].x}
+            y2={p.c[0].y}
+            strokeWidth={0.0015 * w}
+            strokeDasharray={0.003 * w}
+          />
+          <line
+            className={"buldreinfo-svg-pointer"}
+            style={{ fill: "none", stroke: stroke }}
+            x1={p.x}
+            y1={p.y}
+            x2={p.c[1].x}
+            y2={p.c[1].y}
+            strokeWidth={0.0015 * w}
+            strokeDasharray={0.003 * w}
+          />
+          <circle
+            className={"buldreinfo-svg-pointer"}
+            fill={stroke}
+            cx={p.c[0].x}
+            cy={p.c[0].y}
+            r={0.002 * w}
+            onMouseDown={() => setCurrDraggedCubic(i, 0)}
+          />
+          <circle
+            className={"buldreinfo-svg-pointer"}
+            fill={stroke}
+            cx={p.c[1].x}
+            cy={p.c[1].y}
+            r={0.002 * w}
+            onMouseDown={() => setCurrDraggedCubic(i, 1)}
           />
         </g>
       );
-    });
-    anchors.map((a, i) => {
-      circles.push(
-        <circle key={i} fill="#E2011A" cx={a.x} cy={a.y} r={0.006 * w} />
-      );
-    });
-    const myTexts = texts.map((t, i) => (
-      <text key={i} x={t.x} y={t.y} fontSize="5em" fill={"red"}>
-        {t.txt}
-      </text>
-    ));
+    }
+    const fill = activePoint === i ? "#00FF00" : "#FF0000";
     return (
-      <Container onMouseUp={cancelDragging} onMouseLeave={cancelDragging}>
-        <Segment style={{ minHeight: "130px" }}>
-          <Button.Group floated="right">
-            <Button
-              negative
-              disabled={
-                points.length === 0 &&
-                anchors.length === 0 &&
-                myTexts.length === 0
-              }
-              onClick={reset}
-            >
-              Reset
-            </Button>
-            <Button.Or />
-            <Button
-              onClick={() =>
-                navigate(`/problem/${problemIdMediaId?.split("-")[0]}`)
-              }
-            >
-              Cancel
-            </Button>
-            <Button.Or />
-            <Button positive loading={saving} onClick={save}>
-              Save
-            </Button>
-          </Button.Group>
-          <Button.Group size="tiny">
-            <Button onClick={onAddText}>
-              {addText ? "Click on image to add text" : "Add text"}
-            </Button>
-            <Button.Or />
-            <Button
-              disabled={myTexts.length === 0}
-              onClick={() => setTexts([])}
-            >
-              Remove all texts
-            </Button>
-          </Button.Group>
-          {meta.isClimbing && (
-            <>
-              {" "}
-              <Button.Group size="tiny">
-                <Button onClick={onAddAnchor}>
-                  {addAnchor
-                    ? "Click on image to add extra anchor"
-                    : "Add extra anchor"}
-                </Button>
-                <Button.Or />
-                <Button
-                  disabled={anchors.length === 0}
-                  onClick={() => setAnchors([])}
-                >
-                  Remove all extra anchors
-                </Button>
-              </Button.Group>{" "}
-              <Dropdown
-                selection
-                value={hasAnchor}
-                disabled={points.length === 0}
-                onChange={() => setHasAnchor(!hasAnchor)}
-                options={[
-                  { key: 1, value: false, text: "No anchor on route" },
-                  { key: 2, value: true, text: "Route has anchor" },
-                ]}
-              />
-            </>
-          )}
-          <br />
-          <strong>SHIFT + CLICK</strong> to add a point | <strong>CLICK</strong>{" "}
-          to select a point | <strong>CLICK AND DRAG</strong> to move a point
-          <br />
-          {activePoint !== 0 && (
+      <g key={i}>
+        {anchors}
+        <circle
+          className={"buldreinfo-svg-pointer"}
+          fill={black}
+          cx={p.x}
+          cy={p.y}
+          r={0.004 * w}
+          onMouseDown={() => setCurrDraggedPoint(i)}
+        />
+        <circle
+          className={"buldreinfo-svg-pointer"}
+          fill={fill}
+          cx={p.x}
+          cy={p.y}
+          r={0.003 * w}
+          onMouseDown={() => setCurrDraggedPoint(i)}
+        />
+      </g>
+    );
+  });
+  anchors.map((a, i) => {
+    circles.push(
+      <circle key={i} fill="#E2011A" cx={a.x} cy={a.y} r={0.006 * w} />
+    );
+  });
+  const myTexts = texts.map((t, i) => (
+    <text key={i} x={t.x} y={t.y} fontSize="5em" fill={"red"}>
+      {t.txt}
+    </text>
+  ));
+  return (
+    <Container onMouseUp={cancelDragging} onMouseLeave={cancelDragging}>
+      <Segment style={{ minHeight: "130px" }}>
+        <Button.Group floated="right">
+          <Button
+            negative
+            disabled={
+              points.length === 0 &&
+              anchors.length === 0 &&
+              myTexts.length === 0
+            }
+            onClick={reset}
+          >
+            Reset
+          </Button>
+          <Button.Or />
+          <Button onClick={() => navigate(`/problem/${problemId}`)}>
+            Cancel
+          </Button>
+          <Button.Or />
+          <Button positive loading={saving} onClick={save}>
+            Save
+          </Button>
+        </Button.Group>
+        <Button.Group size="tiny">
+          <Button onClick={onAddText}>
+            {addText ? "Click on image to add text" : "Add text"}
+          </Button>
+          <Button.Or />
+          <Button disabled={myTexts.length === 0} onClick={() => setTexts([])}>
+            Remove all texts
+          </Button>
+        </Button.Group>
+        {meta.isClimbing && (
+          <>
+            {" "}
+            <Button.Group size="tiny">
+              <Button onClick={onAddAnchor}>
+                {addAnchor
+                  ? "Click on image to add extra anchor"
+                  : "Add extra anchor"}
+              </Button>
+              <Button.Or />
+              <Button
+                disabled={anchors.length === 0}
+                onClick={() => setAnchors([])}
+              >
+                Remove all extra anchors
+              </Button>
+            </Button.Group>{" "}
             <Dropdown
               selection
-              value={points[activePoint].c ? "C" : "L"}
-              onChange={(...args) => {
-                // @ts-expect-error - I don't know how to fix this right now.
-                return setPointType(...args);
-              }}
+              value={hasAnchor}
+              disabled={points.length === 0}
+              onChange={() => setHasAnchor(!hasAnchor)}
               options={[
-                { key: 1, value: "L", text: "Selected point: Line to" },
-                { key: 2, value: "C", text: "Selected point: Curve to" },
+                { key: 1, value: false, text: "No anchor on route" },
+                { key: 2, value: true, text: "Route has anchor" },
               ]}
             />
-          )}
-          <Button
-            disabled={!points || points.length === 0}
-            onClick={removeActivePoint}
-          >
-            Remove this point
-          </Button>
-        </Segment>
-        <svg
-          viewBox={"0 0 " + w + " " + h}
-          onClick={handleOnClick}
-          onMouseMove={handleMouseMove}
+          </>
+        )}
+        <br />
+        <strong>SHIFT + CLICK</strong> to add a point | <strong>CLICK</strong>{" "}
+        to select a point | <strong>CLICK AND DRAG</strong> to move a point
+        <br />
+        {activePoint !== 0 && (
+          <Dropdown
+            selection
+            value={points[activePoint].c ? "C" : "L"}
+            onChange={(...args) => {
+              // @ts-expect-error - I don't know how to fix this right now.
+              return setPointType(...args);
+            }}
+            options={[
+              { key: 1, value: "L", text: "Selected point: Line to" },
+              { key: 2, value: "C", text: "Selected point: Curve to" },
+            ]}
+          />
+        )}
+        <Button
+          disabled={!points || points.length === 0}
+          onClick={removeActivePoint}
+        >
+          Remove this point
+        </Button>
+      </Segment>
+      <svg
+        viewBox={"0 0 " + w + " " + h}
+        onClick={handleOnClick}
+        onMouseMove={handleMouseMove}
+        width="100%"
+        height="100%"
+      >
+        <image
+          ref={imageRef}
+          xlinkHref={getImageUrl(mediaId, crc32, undefined)}
           width="100%"
           height="100%"
-        >
-          <image
-            ref={imageRef}
-            xlinkHref={getImageUrl(mediaId, crc32, undefined)}
-            width="100%"
-            height="100%"
-          />
-          {parseReadOnlySvgs(readOnlySvgs, w, h, minWindowScale)}
-          <path
-            style={{ fill: "none", stroke: black }}
-            d={path}
-            strokeWidth={0.003 * w}
-          />
-          <path
-            style={{ fill: "none", stroke: "#FF0000" }}
-            d={path}
-            strokeWidth={0.002 * w}
-          />
-          {circles}
-          {myTexts}
-        </svg>
-        <br />
-        <Input
-          label="SVG Path:"
-          action={{
-            labelPosition: "right",
-            color: path === pathTxt ? "grey" : "blue",
-            icon: "sync",
-            content: "Update",
-            onClick: () => {
-              const correctPoints = parsePath(pathTxt);
-              const correctPathTxt = generatePath(correctPoints);
-              setPath(correctPathTxt);
-              setPathTxt(correctPathTxt);
-              setPoints(correctPoints);
-            },
-          }}
-          fluid
-          placeholder="SVG Path"
-          value={pathTxt || ""}
-          onChange={(e, { value }) => {
-            setPathTxt(value);
-          }}
         />
-      </Container>
-    );
-  }
+        {parseReadOnlySvgs(readOnlySvgs, w, h, minWindowScale)}
+        <path
+          style={{ fill: "none", stroke: black }}
+          d={path}
+          strokeWidth={0.003 * w}
+        />
+        <path
+          style={{ fill: "none", stroke: "#FF0000" }}
+          d={path}
+          strokeWidth={0.002 * w}
+        />
+        {circles}
+        {myTexts}
+      </svg>
+      <br />
+      <Input
+        label="SVG Path:"
+        action={{
+          labelPosition: "right",
+          color: path === pathTxt ? "grey" : "blue",
+          icon: "sync",
+          content: "Update",
+          onClick: () => {
+            const correctPoints = parsePath(pathTxt);
+            const correctPathTxt = generatePath(correctPoints);
+            setPath(correctPathTxt);
+            setPathTxt(correctPathTxt);
+            setPoints(correctPoints);
+          },
+        }}
+        fluid
+        placeholder="SVG Path"
+        value={pathTxt || ""}
+        onChange={(e, { value }) => {
+          setPathTxt(value);
+        }}
+      />
+    </Container>
+  );
 };
 
 export default SvgEdit;

--- a/src/components/common/media/media-modal.tsx
+++ b/src/components/common/media/media-modal.tsx
@@ -482,7 +482,7 @@ const MediaModal = ({
                       icon="paint brush"
                       text="Draw topo line"
                       onClick={() =>
-                        navigate(`/problem/svg-edit/${optProblemId}-${m.id}`)
+                        navigate(`/problem/svg-edit/${optProblemId}/${m.id}`)
                       }
                     />
                   )}


### PR DESCRIPTION
In a few places, the URL needed to store two IDs. These were generally encoded a `{firstId}-{secondId}` and then parsed at runtime (often several times).

Instead, define new routes so that they can be provided as `/{firstId}/{secondId}`, like a standard URI.