### PR TITLE
feat: Centralize permissions-checking

### DIFF
--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -2,6 +2,10 @@ import React, { lazy, Suspense, useLayoutEffect } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { Loading } from "./common/widgets/widgets";
 
+const AuthContainer = lazy(
+  () => import(/* webpackChunkName: "auth" */ "./AuthContainer")
+);
+
 const About = lazy(() => import(/* webpackChunkName: "about" */ "./About"));
 const Area = lazy(() => import(/* webpackChunkName: "area" */ "./Area"));
 const AreaEdit = lazy(
@@ -80,14 +84,35 @@ function AppRoutes() {
           <Route path="/" element={<Frontpage />} />
           <Route path="/about" element={<About />} />
           <Route path="/area/:areaId" element={<Area />} />
-          <Route path="/area/edit/:areaId" element={<AreaEdit />} />
+          <Route
+            path="/area/edit/:areaId"
+            element={
+              <AuthContainer level="admin">
+                <AreaEdit />
+              </AuthContainer>
+            }
+          />
           <Route path="/areas" element={<Areas />} />
           <Route path="/dangerous" element={<Dangerous />} />
           <Route path="/donations" element={<Donations />} />
           <Route path="/filter" element={<Filter />} />
           <Route path="/graph" element={<Graph />} />
-          <Route path="/media/svg-edit/:mediaId" element={<MediaSvgEdit />} />
-          <Route path="/permissions" element={<Permissions />} />
+          <Route
+            path="/media/svg-edit/:mediaId"
+            element={
+              <AuthContainer level="admin">
+                <MediaSvgEdit />
+              </AuthContainer>
+            }
+          />
+          <Route
+            path="/permissions"
+            element={
+              <AuthContainer level="super-admin">
+                <Permissions />
+              </AuthContainer>
+            }
+          />
           <Route path="/privacy-policy" element={<PrivacyPolicy />} />
           <Route path="/problem/:problemId" element={<Problem />} />
           {/*
@@ -96,15 +121,27 @@ function AppRoutes() {
           */}
           <Route
             path="/problem/edit/:sectorIdProblemId"
-            element={<ProblemEdit />}
+            element={
+              <AuthContainer level="admin">
+                <ProblemEdit />
+              </AuthContainer>
+            }
           />
           <Route
             path="/problem/edit/media/:problemId"
-            element={<ProblemEditMedia />}
+            element={
+              <AuthContainer level="logged-in">
+                <ProblemEditMedia />
+              </AuthContainer>
+            }
           />
           <Route
             path="/problem/edit/:sectorId/:problemId"
-            element={<ProblemEdit />}
+            element={
+              <AuthContainer level="admin">
+                <ProblemEdit />
+              </AuthContainer>
+            }
           />
           {/*
             Deprecated. Remove this after July 15 or so - just in case anyone
@@ -112,11 +149,19 @@ function AppRoutes() {
           */}
           <Route
             path="/problem/svg-edit/:problemIdMediaId"
-            element={<SvgEdit />}
+            element={
+              <AuthContainer level="admin">
+                <SvgEdit />
+              </AuthContainer>
+            }
           />
           <Route
             path="/problem/svg-edit/:problemId/:mediaId"
-            element={<SvgEdit />}
+            element={
+              <AuthContainer level="admin">
+                <SvgEdit />
+              </AuthContainer>
+            }
           />
           <Route path="/problems" element={<Problems />} />
           <Route path="/sites/:type" element={<Sites />} />
@@ -125,17 +170,56 @@ function AppRoutes() {
             Deprecated. Remove this after July 15 or so - just in case anyone
             has active sessions or something.
           */}
-          <Route path="/sector/edit/:areaIdSectorId" element={<SectorEdit />} />
+          <Route
+            path="/sector/edit/:areaIdSectorId"
+            element={
+              <AuthContainer level="admin">
+                <SectorEdit />
+              </AuthContainer>
+            }
+          />
           <Route
             path="/sector/edit/:areaId/:sectorId"
-            element={<SectorEdit />}
+            element={
+              <AuthContainer level="admin">
+                <SectorEdit />
+              </AuthContainer>
+            }
           />
           <Route path="/ticks/:page" element={<Ticks />} />
           <Route path="/swagger" element={<Swagger />} />
-          <Route path="/trash" element={<Trash />} />
-          <Route path="/user" element={<Profile />} />
-          <Route path="/user/:userId" element={<Profile />} />
-          <Route path="/user/:userId/:page" element={<Profile />} />
+          <Route
+            path="/trash"
+            element={
+              <AuthContainer level="super-admin">
+                <Trash />
+              </AuthContainer>
+            }
+          />
+          <Route
+            path="/user"
+            element={
+              <AuthContainer level="logged-in">
+                <Profile />
+              </AuthContainer>
+            }
+          />
+          <Route
+            path="/user/:userId"
+            element={
+              <AuthContainer level="logged-in">
+                <Profile />
+              </AuthContainer>
+            }
+          />
+          <Route
+            path="/user/:userId/:page"
+            element={
+              <AuthContainer level="logged-in">
+                <Profile />
+              </AuthContainer>
+            }
+          />
           <Route path="/webcams" element={<Webcams />} />
           <Route path="/webcams/:json" element={<Webcams />} />
         </Routes>

--- a/src/components/AreaEdit.tsx
+++ b/src/components/AreaEdit.tsx
@@ -17,23 +17,18 @@ import {
 import { useAuth0 } from "@auth0/auth0-react";
 import { useMeta } from "./common/meta";
 import { getAreaEdit, postArea } from "../api";
-import { Loading, InsufficientPrivileges } from "./common/widgets/widgets";
-import { useNavigate, useParams, useLocation } from "react-router-dom";
+import { Loading } from "./common/widgets/widgets";
+import { useNavigate, useParams } from "react-router-dom";
 
 const AreaEdit = () => {
-  const {
-    isLoading,
-    isAuthenticated,
-    getAccessTokenSilently,
-    loginWithRedirect,
-  } = useAuth0();
+  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
   const meta = useMeta();
   const [data, setData] = useState<any>(null);
   const [showSectorOrder, setShowSectorOrder] = useState(false);
   const [saving, setSaving] = useState(false);
   const { areaId } = useParams();
   const navigate = useNavigate();
-  const location = useLocation();
+
   useEffect(() => {
     if (!isLoading && areaId && isAuthenticated) {
       getAccessTokenSilently().then((accessToken) => {
@@ -111,267 +106,258 @@ const AreaEdit = () => {
     }));
   }
 
-  if (isLoading || (isAuthenticated && !data)) {
+  if (!data) {
     return <Loading />;
-  } else if (!isAuthenticated) {
-    loginWithRedirect({ appState: { returnTo: location.pathname } });
-  } else if (!meta.isAdmin) {
-    return <InsufficientPrivileges />;
-  } else {
-    const defaultCenter =
-      data.lat && data.lng && parseFloat(data.lat) > 0
-        ? { lat: parseFloat(data.lat), lng: parseFloat(data.lng) }
-        : meta.defaultCenter;
-    const defaultZoom: number =
-      data.lat && parseFloat(data.lat) > 0 ? 8 : meta.defaultZoom;
-    const lockedOptions = [
-      { key: 0, value: 0, text: "Visible for everyone" },
-      { key: 1, value: 1, text: "Only visible for administrators" },
-    ];
-    if (meta.isSuperAdmin) {
-      lockedOptions.push({
-        key: 2,
-        value: 2,
-        text: "Only visible for super administrators",
-      });
-    }
-    let lockedValue = 0;
-    if (data.lockedSuperadmin) {
-      lockedValue = 2;
-    } else if (data.lockedAdmin) {
-      lockedValue = 1;
-    }
-
-    const orderForm = data.sectorOrder?.length > 1 && (
-      <>
-        {data.sectorOrder.map((s, i) => {
-          const sectorOrder = data.sectorOrder;
-          const clr =
-            sectorOrder[i].origSorting &&
-            sectorOrder[i].origSorting != sectorOrder[i].sorting
-              ? "orange"
-              : "gray";
-          return (
-            <Input
-              key={s.id}
-              size="small"
-              fluid
-              icon="hashtag"
-              iconPosition="left"
-              placeholder="Number"
-              value={s.sorting}
-              label={{ basic: true, content: s.name, color: clr }}
-              labelPosition="right"
-              onChange={(e, { value }) => {
-                if (sectorOrder[i].origSorting === undefined) {
-                  sectorOrder[i].origSorting = sectorOrder[i].sorting;
-                }
-                sectorOrder[i].sorting = parseInt(value) || "";
-                setData((prevState) => ({ ...prevState, sectorOrder }));
-              }}
-            />
-          );
-        })}
-      </>
-    );
-
-    return (
-      <>
-        <Helmet>
-          <title>
-            Edit {data.name} | {meta.title}
-          </title>
-        </Helmet>
-        <Message
-          size="tiny"
-          content={
-            <>
-              <Icon name="info" />
-              Contact{" "}
-              <a href="mailto:jostein.oygarden@gmail.com">
-                Jostein Øygarden
-              </a>{" "}
-              if you want to split area.
-            </>
-          }
-        />
-        <Form>
-          <Segment>
-            <Form.Group widths="equal">
-              <Form.Field
-                label="Area name"
-                control={Input}
-                placeholder="Enter name"
-                value={data.name}
-                onChange={onNameChanged}
-                error={data.name ? false : "Area name required"}
-              />
-              <Form.Field
-                label="Visibility"
-                control={Dropdown}
-                selection
-                value={lockedValue}
-                onChange={onLockedChanged}
-                options={lockedOptions}
-              />
-              <Form.Field>
-                <label>For developers</label>
-                <Checkbox
-                  toggle
-                  checked={data.forDevelopers}
-                  onChange={() =>
-                    setData((prevState) => ({
-                      ...prevState,
-                      forDevelopers: !data.forDevelopers,
-                    }))
-                  }
-                />
-              </Form.Field>
-              <Form.Field>
-                <label>No dogs allowed</label>
-                <Checkbox
-                  toggle
-                  checked={data.noDogsAllowed}
-                  onChange={() =>
-                    setData((prevState) => ({
-                      ...prevState,
-                      noDogsAllowed: !data.noDogsAllowed,
-                    }))
-                  }
-                />
-              </Form.Field>
-              <Form.Field>
-                <label>Move to trash</label>
-                <Checkbox
-                  disabled={!data.id || data.id <= 0}
-                  toggle
-                  checked={data.trash}
-                  onChange={() =>
-                    setData((prevState) => ({
-                      ...prevState,
-                      trash: !data.trash,
-                    }))
-                  }
-                />
-              </Form.Field>
-            </Form.Group>
-            <Form.Field>
-              <label>
-                Description (supports remarkable formatting, more info{" "}
-                <a
-                  href="https://jonschlinkert.github.io/remarkable/demo/"
-                  rel="noreferrer noopener"
-                  target="_blank"
-                >
-                  here
-                </a>
-                )
-              </label>
-              <TextArea
-                placeholder="Enter description"
-                style={{ minHeight: 100 }}
-                value={data.comment}
-                onChange={onCommentChanged}
-              />
-            </Form.Field>
-            <Form.Field>
-              <Input
-                label="Area closed:"
-                placeholder="Enter closed-reason..."
-                value={data.accessClosed}
-                onChange={onAccessClosedChanged}
-                icon="attention"
-              />
-            </Form.Field>
-            <Form.Field>
-              <Input
-                label="Area restrictions:"
-                placeholder="Enter specific restrictions..."
-                value={data.accessInfo}
-                onChange={onAccessInfoChanged}
-              />
-            </Form.Field>
-          </Segment>
-
-          <Segment>
-            <Form.Field
-              label="Upload image(s)"
-              control={ImageUpload}
-              onMediaChanged={onNewMediaChanged}
-              isMultiPitch={false}
-              includeVideoEmbedder={false}
-            />
-          </Segment>
-
-          <Segment>
-            <Form.Field>
-              <label>Click to mark area center on map</label>
-              <Leaflet
-                autoZoom={true}
-                markers={
-                  data.lat != 0 &&
-                  data.lng != 0 && [{ lat: data.lat, lng: data.lng }]
-                }
-                defaultCenter={defaultCenter}
-                defaultZoom={defaultZoom}
-                onMouseClick={onMarkerClick}
-                onMouseMove={null}
-                polylines={null}
-                outlines={null}
-                height={"300px"}
-                showSateliteImage={false}
-                clusterMarkers={false}
-                rocks={null}
-                flyToId={null}
-              />
-            </Form.Field>
-          </Segment>
-
-          {orderForm && (
-            <Segment>
-              <Accordion>
-                <Accordion.Title
-                  active={showSectorOrder}
-                  onClick={() => setShowSectorOrder(!showSectorOrder)}
-                >
-                  <Icon name="dropdown" />
-                  Change order of sectors in area
-                </Accordion.Title>
-                <Accordion.Content
-                  active={showSectorOrder}
-                  content={orderForm}
-                />
-              </Accordion>
-            </Segment>
-          )}
-
-          <Button.Group>
-            <Button
-              negative
-              onClick={() => {
-                if (areaId && areaId != "-1") {
-                  navigate(`/area/${areaId}`);
-                } else {
-                  navigate(`/areas`);
-                }
-              }}
-            >
-              Cancel
-            </Button>
-            <Button.Or />
-            <Button
-              positive
-              loading={saving}
-              onClick={save}
-              disabled={!data.name}
-            >
-              Save area
-            </Button>
-          </Button.Group>
-        </Form>
-      </>
-    );
   }
+
+  const defaultCenter =
+    data.lat && data.lng && parseFloat(data.lat) > 0
+      ? { lat: parseFloat(data.lat), lng: parseFloat(data.lng) }
+      : meta.defaultCenter;
+  const defaultZoom: number =
+    data.lat && parseFloat(data.lat) > 0 ? 8 : meta.defaultZoom;
+  const lockedOptions = [
+    { key: 0, value: 0, text: "Visible for everyone" },
+    { key: 1, value: 1, text: "Only visible for administrators" },
+  ];
+  if (meta.isSuperAdmin) {
+    lockedOptions.push({
+      key: 2,
+      value: 2,
+      text: "Only visible for super administrators",
+    });
+  }
+  let lockedValue = 0;
+  if (data.lockedSuperadmin) {
+    lockedValue = 2;
+  } else if (data.lockedAdmin) {
+    lockedValue = 1;
+  }
+
+  const orderForm = data.sectorOrder?.length > 1 && (
+    <>
+      {data.sectorOrder.map((s, i) => {
+        const sectorOrder = data.sectorOrder;
+        const clr =
+          sectorOrder[i].origSorting &&
+          sectorOrder[i].origSorting != sectorOrder[i].sorting
+            ? "orange"
+            : "gray";
+        return (
+          <Input
+            key={s.id}
+            size="small"
+            fluid
+            icon="hashtag"
+            iconPosition="left"
+            placeholder="Number"
+            value={s.sorting}
+            label={{ basic: true, content: s.name, color: clr }}
+            labelPosition="right"
+            onChange={(e, { value }) => {
+              if (sectorOrder[i].origSorting === undefined) {
+                sectorOrder[i].origSorting = sectorOrder[i].sorting;
+              }
+              sectorOrder[i].sorting = parseInt(value) || "";
+              setData((prevState) => ({ ...prevState, sectorOrder }));
+            }}
+          />
+        );
+      })}
+    </>
+  );
+
+  return (
+    <>
+      <Helmet>
+        <title>
+          Edit {data.name} | {meta.title}
+        </title>
+      </Helmet>
+      <Message
+        size="tiny"
+        content={
+          <>
+            <Icon name="info" />
+            Contact{" "}
+            <a href="mailto:jostein.oygarden@gmail.com">Jostein Øygarden</a> if
+            you want to split area.
+          </>
+        }
+      />
+      <Form>
+        <Segment>
+          <Form.Group widths="equal">
+            <Form.Field
+              label="Area name"
+              control={Input}
+              placeholder="Enter name"
+              value={data.name}
+              onChange={onNameChanged}
+              error={data.name ? false : "Area name required"}
+            />
+            <Form.Field
+              label="Visibility"
+              control={Dropdown}
+              selection
+              value={lockedValue}
+              onChange={onLockedChanged}
+              options={lockedOptions}
+            />
+            <Form.Field>
+              <label>For developers</label>
+              <Checkbox
+                toggle
+                checked={data.forDevelopers}
+                onChange={() =>
+                  setData((prevState) => ({
+                    ...prevState,
+                    forDevelopers: !data.forDevelopers,
+                  }))
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>No dogs allowed</label>
+              <Checkbox
+                toggle
+                checked={data.noDogsAllowed}
+                onChange={() =>
+                  setData((prevState) => ({
+                    ...prevState,
+                    noDogsAllowed: !data.noDogsAllowed,
+                  }))
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Move to trash</label>
+              <Checkbox
+                disabled={!data.id || data.id <= 0}
+                toggle
+                checked={data.trash}
+                onChange={() =>
+                  setData((prevState) => ({
+                    ...prevState,
+                    trash: !data.trash,
+                  }))
+                }
+              />
+            </Form.Field>
+          </Form.Group>
+          <Form.Field>
+            <label>
+              Description (supports remarkable formatting, more info{" "}
+              <a
+                href="https://jonschlinkert.github.io/remarkable/demo/"
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                here
+              </a>
+              )
+            </label>
+            <TextArea
+              placeholder="Enter description"
+              style={{ minHeight: 100 }}
+              value={data.comment}
+              onChange={onCommentChanged}
+            />
+          </Form.Field>
+          <Form.Field>
+            <Input
+              label="Area closed:"
+              placeholder="Enter closed-reason..."
+              value={data.accessClosed}
+              onChange={onAccessClosedChanged}
+              icon="attention"
+            />
+          </Form.Field>
+          <Form.Field>
+            <Input
+              label="Area restrictions:"
+              placeholder="Enter specific restrictions..."
+              value={data.accessInfo}
+              onChange={onAccessInfoChanged}
+            />
+          </Form.Field>
+        </Segment>
+
+        <Segment>
+          <Form.Field
+            label="Upload image(s)"
+            control={ImageUpload}
+            onMediaChanged={onNewMediaChanged}
+            isMultiPitch={false}
+            includeVideoEmbedder={false}
+          />
+        </Segment>
+
+        <Segment>
+          <Form.Field>
+            <label>Click to mark area center on map</label>
+            <Leaflet
+              autoZoom={true}
+              markers={
+                data.lat != 0 &&
+                data.lng != 0 && [{ lat: data.lat, lng: data.lng }]
+              }
+              defaultCenter={defaultCenter}
+              defaultZoom={defaultZoom}
+              onMouseClick={onMarkerClick}
+              onMouseMove={null}
+              polylines={null}
+              outlines={null}
+              height={"300px"}
+              showSateliteImage={false}
+              clusterMarkers={false}
+              rocks={null}
+              flyToId={null}
+            />
+          </Form.Field>
+        </Segment>
+
+        {orderForm && (
+          <Segment>
+            <Accordion>
+              <Accordion.Title
+                active={showSectorOrder}
+                onClick={() => setShowSectorOrder(!showSectorOrder)}
+              >
+                <Icon name="dropdown" />
+                Change order of sectors in area
+              </Accordion.Title>
+              <Accordion.Content active={showSectorOrder} content={orderForm} />
+            </Accordion>
+          </Segment>
+        )}
+
+        <Button.Group>
+          <Button
+            negative
+            onClick={() => {
+              if (areaId && areaId != "-1") {
+                navigate(`/area/${areaId}`);
+              } else {
+                navigate(`/areas`);
+              }
+            }}
+          >
+            Cancel
+          </Button>
+          <Button.Or />
+          <Button
+            positive
+            loading={saving}
+            onClick={save}
+            disabled={!data.name}
+          >
+            Save area
+          </Button>
+        </Button.Group>
+      </Form>
+    </>
+  );
 };
 
 export default AreaEdit;

--- a/src/components/AuthContainer/AuthContainer.tsx
+++ b/src/components/AuthContainer/AuthContainer.tsx
@@ -1,0 +1,36 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import React from "react";
+import {
+  InsufficientPrivileges,
+  Loading,
+  NotLoggedIn,
+} from "../common/widgets/widgets";
+import { useMeta } from "../common/meta";
+
+type Props = {
+  children: React.ReactNode;
+  level: "logged-in" | "admin" | "super-admin";
+};
+
+export const AuthContainer = ({ children, level }: Props) => {
+  const { isAuthenticated, isLoading } = useAuth0();
+  const meta = useMeta();
+
+  if (isLoading || !meta) {
+    return <Loading />;
+  }
+
+  if (!isAuthenticated || !meta.isAuthenticated) {
+    return <NotLoggedIn />;
+  }
+
+  if (level === "admin" && !meta.isAdmin) {
+    return <InsufficientPrivileges />;
+  }
+
+  if (level === "super-admin" && !meta.isSuperAdmin) {
+    return <InsufficientPrivileges />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/components/AuthContainer/index.ts
+++ b/src/components/AuthContainer/index.ts
@@ -1,0 +1,1 @@
+export { AuthContainer as default } from "./AuthContainer";

--- a/src/components/MediaSvgEdit.tsx
+++ b/src/components/MediaSvgEdit.tsx
@@ -7,15 +7,9 @@ import {
   Segment,
   Dropdown,
 } from "semantic-ui-react";
-import { useAuth0 } from "@auth0/auth0-react";
-import { useMeta } from "./common/meta";
 import { getImageUrl, useMediaSvg } from "../api";
 import { Rappel, parseReadOnlySvgs, parsePath } from "../utils/svg-utils";
-import {
-  Loading,
-  InsufficientPrivileges,
-  NotLoggedIn,
-} from "./common/widgets/widgets";
+import { Loading } from "./common/widgets/widgets";
 import { useNavigate, useParams } from "react-router-dom";
 
 const TYPE_PATH = "PATH";
@@ -23,8 +17,6 @@ const TYPE_RAPPEL_BOLTED = "RAPPEL_BOLTED";
 const TYPE_RAPPEL_NOT_BOLTED = "RAPPEL_NOT_BOLTED";
 
 const MediaSvgEdit = () => {
-  const { isAuthenticated } = useAuth0();
-  const meta = useMeta();
   const navigate = useNavigate();
   const { mediaId } = useParams();
   const { outerWidth, outerHeight } = window;
@@ -267,14 +259,6 @@ const MediaSvgEdit = () => {
 
   if (!data || isLoading) {
     return <Loading />;
-  }
-
-  if (!isAuthenticated) {
-    return <NotLoggedIn />;
-  }
-
-  if (!meta.isAdmin) {
-    return <InsufficientPrivileges />;
   }
 
   const circles =

--- a/src/components/Permissions.tsx
+++ b/src/components/Permissions.tsx
@@ -11,21 +11,14 @@ import {
   Dropdown,
   Card,
 } from "semantic-ui-react";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
-import { InsufficientPrivileges } from "./common/widgets/widgets";
 
 const Permissions = () => {
-  const {
-    isLoading,
-    isAuthenticated,
-    getAccessTokenSilently,
-    loginWithRedirect,
-  } = useAuth0();
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
   const meta = useMeta();
   const [accessToken, setAccessToken] = useState<any>(null);
   const [data, setData] = useState<any>(null);
-  const location = useLocation();
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -38,129 +31,124 @@ const Permissions = () => {
     }
   }, [getAccessTokenSilently, isAuthenticated]);
 
-  if (isLoading || (isAuthenticated && !data)) {
+  if (!data) {
     return <Loading />;
-  } else if (!isAuthenticated) {
-    loginWithRedirect({ appState: { returnTo: location.pathname } });
-  } else if (!meta.isSuperAdmin) {
-    return <InsufficientPrivileges />;
-  } else {
-    return (
-      <>
-        <Helmet>
-          <title>Permissions | {meta.title}</title>
-        </Helmet>
-        <Segment>
-          <Header as="h2">
-            <Icon name="users" />
-            <Header.Content>
-              Permissions
-              <Header.Subheader>{data.length} users</Header.Subheader>
-            </Header.Content>
-          </Header>
-        </Segment>
-        {data.length == 0 ? (
-          <Segment>No data</Segment>
-        ) : (
-          <Card.Group doubling stackable itemsPerRow={4}>
-            {data.map((u, key) => {
-              let color: any = "white";
-              if (u.write == 2) {
-                color = "black";
-              } else if (u.write == 1) {
-                color = "red";
-              } else if (u.write == 0) {
-                color = "green";
-              } else {
-                color = "yellow";
-              }
-              let value = 0;
-              if (u.superadminWrite) {
-                value = 3;
-              } else if (u.adminWrite) {
-                value = 2;
-              } else if (u.adminRead) {
-                value = 1;
-              }
-              return (
-                <Card color={color} key={key} raised>
-                  <Card.Content>
-                    <Image
-                      floated="right"
-                      size="mini"
-                      src={u.picture ? u.picture : "/png/image.png"}
-                    />
-                    <Card.Header as={Link} to={`/user/${u.userId}`}>
-                      {u.name}{" "}
-                      <LockSymbol
-                        lockedAdmin={u.adminRead || u.adminWrite}
-                        lockedSuperadmin={u.superadminRead || u.superadminWrite}
-                      />
-                    </Card.Header>
-                    <Card.Meta>Last seen {u.lastLogin}</Card.Meta>
-                    <Card.Description>
-                      <Dropdown
-                        value={value}
-                        disabled={u.readOnly}
-                        options={[
-                          {
-                            key: 0,
-                            value: 0,
-                            icon: "user",
-                            text: "Default user",
-                          },
-                          {
-                            key: 1,
-                            value: 1,
-                            icon: "user plus",
-                            text: "Read hidden data",
-                          },
-                          {
-                            key: 2,
-                            value: 2,
-                            icon: "lock",
-                            text: "Admin (read+write hidden data)",
-                          },
-                          {
-                            key: 3,
-                            value: 3,
-                            icon: "user secret",
-                            text: "Admin + manage users",
-                          },
-                        ]}
-                        onChange={(e, d) => {
-                          const adminRead = d.value === 1 || d.value === 2;
-                          const adminWrite = d.value === 2;
-                          const superadminRead = d.value === 3;
-                          const superadminWrite = d.value === 3;
-                          postPermissions(
-                            accessToken,
-                            u.userId,
-                            adminRead,
-                            adminWrite,
-                            superadminRead,
-                            superadminWrite
-                          )
-                            .then(() => {
-                              window.scrollTo(0, 0);
-                              window.location.reload();
-                            })
-                            .catch((error) => {
-                              console.warn(error);
-                              alert(error.toString());
-                            });
-                        }}
-                      />
-                    </Card.Description>
-                  </Card.Content>
-                </Card>
-              );
-            })}
-          </Card.Group>
-        )}
-      </>
-    );
   }
+  return (
+    <>
+      <Helmet>
+        <title>Permissions | {meta.title}</title>
+      </Helmet>
+      <Segment>
+        <Header as="h2">
+          <Icon name="users" />
+          <Header.Content>
+            Permissions
+            <Header.Subheader>{data.length} users</Header.Subheader>
+          </Header.Content>
+        </Header>
+      </Segment>
+      {data.length == 0 ? (
+        <Segment>No data</Segment>
+      ) : (
+        <Card.Group doubling stackable itemsPerRow={4}>
+          {data.map((u, key) => {
+            let color: any = "white";
+            if (u.write == 2) {
+              color = "black";
+            } else if (u.write == 1) {
+              color = "red";
+            } else if (u.write == 0) {
+              color = "green";
+            } else {
+              color = "yellow";
+            }
+            let value = 0;
+            if (u.superadminWrite) {
+              value = 3;
+            } else if (u.adminWrite) {
+              value = 2;
+            } else if (u.adminRead) {
+              value = 1;
+            }
+            return (
+              <Card color={color} key={key} raised>
+                <Card.Content>
+                  <Image
+                    floated="right"
+                    size="mini"
+                    src={u.picture ? u.picture : "/png/image.png"}
+                  />
+                  <Card.Header as={Link} to={`/user/${u.userId}`}>
+                    {u.name}{" "}
+                    <LockSymbol
+                      lockedAdmin={u.adminRead || u.adminWrite}
+                      lockedSuperadmin={u.superadminRead || u.superadminWrite}
+                    />
+                  </Card.Header>
+                  <Card.Meta>Last seen {u.lastLogin}</Card.Meta>
+                  <Card.Description>
+                    <Dropdown
+                      value={value}
+                      disabled={u.readOnly}
+                      options={[
+                        {
+                          key: 0,
+                          value: 0,
+                          icon: "user",
+                          text: "Default user",
+                        },
+                        {
+                          key: 1,
+                          value: 1,
+                          icon: "user plus",
+                          text: "Read hidden data",
+                        },
+                        {
+                          key: 2,
+                          value: 2,
+                          icon: "lock",
+                          text: "Admin (read+write hidden data)",
+                        },
+                        {
+                          key: 3,
+                          value: 3,
+                          icon: "user secret",
+                          text: "Admin + manage users",
+                        },
+                      ]}
+                      onChange={(e, d) => {
+                        const adminRead = d.value === 1 || d.value === 2;
+                        const adminWrite = d.value === 2;
+                        const superadminRead = d.value === 3;
+                        const superadminWrite = d.value === 3;
+                        postPermissions(
+                          accessToken,
+                          u.userId,
+                          adminRead,
+                          adminWrite,
+                          superadminRead,
+                          superadminWrite
+                        )
+                          .then(() => {
+                            window.scrollTo(0, 0);
+                            window.location.reload();
+                          })
+                          .catch((error) => {
+                            console.warn(error);
+                            alert(error.toString());
+                          });
+                      }}
+                    />
+                  </Card.Description>
+                </Card.Content>
+              </Card>
+            );
+          })}
+        </Card.Group>
+      )}
+    </>
+  );
 };
 
 export default Permissions;

--- a/src/components/ProblemEdit.tsx
+++ b/src/components/ProblemEdit.tsx
@@ -17,7 +17,6 @@ import {
   Checkbox,
 } from "semantic-ui-react";
 import Leaflet from "./common/leaflet/leaflet";
-import { useAuth0 } from "@auth0/auth0-react";
 import { useMeta } from "./common/meta";
 import {
   getProblemEdit,
@@ -27,11 +26,7 @@ import {
   getSector,
   useAccessToken,
 } from "../api";
-import {
-  Loading,
-  InsufficientPrivileges,
-  NotLoggedIn,
-} from "./common/widgets/widgets";
+import { Loading } from "./common/widgets/widgets";
 import { useNavigate, useParams } from "react-router-dom";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
@@ -49,7 +44,6 @@ const useIds = (): { sectorId: number; problemId: number } => {
 
 const ProblemEdit = () => {
   const accessToken = useAccessToken();
-  const { isAuthenticated } = useAuth0();
   const { sectorId, problemId } = useIds();
   const [data, setData] = useState<any>(null);
   const [sectorMarkers, setSectorMarkers] = useState([]);
@@ -267,14 +261,6 @@ const ProblemEdit = () => {
 
   function onSectionsUpdated(sections) {
     setData((prevState) => ({ ...prevState, sections }));
-  }
-
-  if (!isAuthenticated) {
-    return <NotLoggedIn />;
-  }
-
-  if (!meta.isAdmin) {
-    return <InsufficientPrivileges />;
   }
 
   if (error) {

--- a/src/components/ProblemEditMedia.tsx
+++ b/src/components/ProblemEditMedia.tsx
@@ -4,22 +4,16 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { getProblem, postProblemMedia } from "../api";
 import { Loading } from "./common/widgets/widgets";
 import { Segment, Button } from "semantic-ui-react";
-import { useNavigate, useParams, useLocation } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 const ProblemEditMedia = () => {
-  const {
-    isLoading,
-    isAuthenticated,
-    getAccessTokenSilently,
-    loginWithRedirect,
-  } = useAuth0();
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
   const [id, setId] = useState<any>(null);
   const [isMultiPitch, setIsMultiPitch] = useState(false);
   const [media, setMedia] = useState<any>(null);
   const [saving, setSaving] = useState(false);
   const { problemId } = useParams();
   const navigate = useNavigate();
-  const location = useLocation();
   useEffect(() => {
     if (problemId && isAuthenticated) {
       getAccessTokenSilently().then((accessToken) => {
@@ -45,33 +39,31 @@ const ProblemEditMedia = () => {
     });
   }
 
-  if (isLoading || (isAuthenticated && !id)) {
+  if (!id) {
     return <Loading />;
-  } else if (!isAuthenticated) {
-    loginWithRedirect({ appState: { returnTo: location.pathname } });
-  } else {
-    return (
-      <>
-        <Segment>
-          <h3>Upload image(s) or embed video(s)</h3>
-          <form onSubmit={save}>
-            <ImageUpload
-              onMediaChanged={(newMedia) => setMedia(newMedia)}
-              isMultiPitch={isMultiPitch}
-              includeVideoEmbedder={true}
-            />
-          </form>
-        </Segment>
-        <Button.Group>
-          <Button onClick={() => navigate(`/problem/${id}`)}>Cancel</Button>
-          <Button.Or />
-          <Button type="submit" positive loading={saving}>
-            Save
-          </Button>
-        </Button.Group>
-      </>
-    );
   }
+
+  return (
+    <>
+      <Segment>
+        <h3>Upload image(s) or embed video(s)</h3>
+        <form onSubmit={save}>
+          <ImageUpload
+            onMediaChanged={(newMedia) => setMedia(newMedia)}
+            isMultiPitch={isMultiPitch}
+            includeVideoEmbedder={true}
+          />
+        </form>
+      </Segment>
+      <Button.Group>
+        <Button onClick={() => navigate(`/problem/${id}`)}>Cancel</Button>
+        <Button.Or />
+        <Button type="submit" positive loading={saving}>
+          Save
+        </Button>
+      </Button.Group>
+    </>
+  );
 };
 
 export default ProblemEditMedia;

--- a/src/components/SectorEdit.tsx
+++ b/src/components/SectorEdit.tsx
@@ -3,11 +3,7 @@ import GpxParser from "gpxparser";
 import Dropzone from "react-dropzone";
 import { Helmet } from "react-helmet";
 import ImageUpload from "./common/image-upload/image-upload";
-import {
-  Loading,
-  InsufficientPrivileges,
-  NotLoggedIn,
-} from "./common/widgets/widgets";
+import { Loading } from "./common/widgets/widgets";
 import {
   Checkbox,
   Form,
@@ -20,7 +16,6 @@ import {
   Icon,
   Message,
 } from "semantic-ui-react";
-import { useAuth0 } from "@auth0/auth0-react";
 import { useMeta } from "./common/meta";
 import {
   getSectorEdit,
@@ -45,7 +40,6 @@ const useIds = (): { areaId: number; sectorId: number } => {
 
 const SectorEdit = () => {
   const accessToken = useAccessToken();
-  const { isLoading, isAuthenticated } = useAuth0();
   const { areaId, sectorId } = useIds();
   const [leafletMode, setLeafletMode] = useState("PARKING");
   const [data, setData] = useState<any>(null);
@@ -189,14 +183,6 @@ const SectorEdit = () => {
     setData((prevState) => ({ ...prevState, lng, lngStr }));
   }
 
-  if (!isAuthenticated) {
-    return <NotLoggedIn />;
-  }
-
-  if (!meta.isAdmin) {
-    return <InsufficientPrivileges />;
-  }
-
   if (error) {
     return (
       <Message
@@ -211,7 +197,7 @@ const SectorEdit = () => {
     );
   }
 
-  if (isLoading || !data) {
+  if (!data) {
     return <Loading />;
   }
 

--- a/src/components/SvgEdit.tsx
+++ b/src/components/SvgEdit.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Container, Button, Segment, Dropdown, Input } from "semantic-ui-react";
-import { useAuth0 } from "@auth0/auth0-react";
 import { useMeta } from "./common/meta";
 import {
   getSvgEdit,
@@ -9,11 +8,7 @@ import {
   useAccessToken,
 } from "../api";
 import { parseReadOnlySvgs, parsePath } from "../utils/svg-utils";
-import {
-  Loading,
-  InsufficientPrivileges,
-  NotLoggedIn,
-} from "./common/widgets/widgets";
+import { Loading } from "./common/widgets/widgets";
 import { useNavigate, useParams } from "react-router-dom";
 
 const useIds = (): { problemId: number; mediaId: number } => {
@@ -31,7 +26,6 @@ const SvgEdit = () => {
   const accessToken = useAccessToken();
   const { problemId, mediaId } = useIds();
   const [saving, setSaving] = useState(false);
-  const { isAuthenticated } = useAuth0();
   const [crc32, setCrc32] = useState<any>(null);
   const [w, setW] = useState<any>(null);
   const [h, setH] = useState<any>(null);
@@ -338,14 +332,6 @@ const SvgEdit = () => {
     setDraggedPoint(false);
     setDraggedCubic(false);
     setHasAnchor(true);
-  }
-
-  if (!isAuthenticated) {
-    return <NotLoggedIn />;
-  }
-
-  if (!meta.isAdmin) {
-    return <InsufficientPrivileges />;
   }
 
   if (!id || !meta) {

--- a/src/components/Trash.tsx
+++ b/src/components/Trash.tsx
@@ -3,113 +3,103 @@ import { Loading } from "./common/widgets/widgets";
 import { useMeta } from "./common/meta";
 import { getImageUrl, useData, putTrash, useAccessToken } from "../api";
 import { Segment, Icon, Header, List, Button, Image } from "semantic-ui-react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { useAuth0 } from "@auth0/auth0-react";
-import { InsufficientPrivileges } from "./common/widgets/widgets";
+import { useNavigate } from "react-router-dom";
 
 const Trash = () => {
-  const { isLoading, isAuthenticated, loginWithRedirect } = useAuth0();
   const accessToken = useAccessToken();
   const meta = useMeta();
   const { data } = useData(`/trash`);
-  const location = useLocation();
   const navigate = useNavigate();
 
-  if (isLoading || (isAuthenticated && !data)) {
+  if (!data) {
     return <Loading />;
-  } else if (!isAuthenticated) {
-    loginWithRedirect({ appState: { returnTo: location.pathname } });
-  } else if (!meta.isSuperAdmin) {
-    return <InsufficientPrivileges />;
-  } else {
-    return (
-      <>
-        <Helmet>
-          <title>Trash | {meta.title}</title>
-        </Helmet>
-        <Segment>
-          <Header as="h2">
-            <Icon name="trash" />
-            <Header.Content>
-              Trash
-              <Header.Subheader>{data.length} items</Header.Subheader>
-            </Header.Content>
-          </Header>
-          {data.length == 0 ? (
-            <i>No data</i>
-          ) : (
-            <List divided verticalAlign="middle">
-              {data.map((t, key) => {
-                let label = null;
-                if (t.idMedia > 0) label = "Media";
-                else if (t.idArea > 0) label = "Area";
-                else if (t.idSector > 0) label = "Sector";
-                else if (t.idProblem > 0) label = "Problem";
-                return (
-                  <List.Item key={key}>
-                    <List.Content floated="right">
-                      <Button
-                        onClick={() => {
-                          if (
-                            confirm("Are you sure you want to restore item?")
-                          ) {
-                            putTrash(
-                              accessToken,
-                              t.idArea,
-                              t.idSector,
-                              t.idProblem,
-                              t.idMedia
-                            )
-                              .then(() => {
-                                let url;
-                                if (t.idArea > 0) {
-                                  url = "/area/" + t.idArea;
-                                } else if (t.idSector > 0) {
-                                  url = "/sector/" + t.idSector;
-                                } else if (t.idProblem > 0) {
-                                  url = "/problem/" + t.idProblem;
-                                }
-                                if (t.idMedia > 0) {
-                                  navigate(url + "?idMedia=" + t.idMedia);
-                                } else {
-                                  navigate(url);
-                                }
-                              })
-                              .catch((error) => {
-                                console.warn(error);
-                              });
-                          }
-                        }}
-                      >
-                        Restore
-                      </Button>
-                    </List.Content>
-                    {t.idMedia > 0 && (
-                      <Image
-                        alt={t.name}
-                        key={t.idMedia}
-                        src={getImageUrl(t.idMedia, null, 50)}
-                        onError={(i) =>
-                          (i.target.src = "/png/video_placeholder.png")
-                        }
-                        rounded
-                      />
-                    )}
-                    <List.Content>
-                      <List.Header>{t.name}</List.Header>
-                      <List.Description>
-                        {label + " deleted by " + t.by + " (" + t.when + ")"}
-                      </List.Description>
-                    </List.Content>
-                  </List.Item>
-                );
-              })}
-            </List>
-          )}
-        </Segment>
-      </>
-    );
   }
+
+  return (
+    <>
+      <Helmet>
+        <title>Trash | {meta.title}</title>
+      </Helmet>
+      <Segment>
+        <Header as="h2">
+          <Icon name="trash" />
+          <Header.Content>
+            Trash
+            <Header.Subheader>{data.length} items</Header.Subheader>
+          </Header.Content>
+        </Header>
+        {data.length == 0 ? (
+          <i>No data</i>
+        ) : (
+          <List divided verticalAlign="middle">
+            {data.map((t, key) => {
+              let label = null;
+              if (t.idMedia > 0) label = "Media";
+              else if (t.idArea > 0) label = "Area";
+              else if (t.idSector > 0) label = "Sector";
+              else if (t.idProblem > 0) label = "Problem";
+              return (
+                <List.Item key={key}>
+                  <List.Content floated="right">
+                    <Button
+                      onClick={() => {
+                        if (confirm("Are you sure you want to restore item?")) {
+                          putTrash(
+                            accessToken,
+                            t.idArea,
+                            t.idSector,
+                            t.idProblem,
+                            t.idMedia
+                          )
+                            .then(() => {
+                              let url;
+                              if (t.idArea > 0) {
+                                url = "/area/" + t.idArea;
+                              } else if (t.idSector > 0) {
+                                url = "/sector/" + t.idSector;
+                              } else if (t.idProblem > 0) {
+                                url = "/problem/" + t.idProblem;
+                              }
+                              if (t.idMedia > 0) {
+                                navigate(url + "?idMedia=" + t.idMedia);
+                              } else {
+                                navigate(url);
+                              }
+                            })
+                            .catch((error) => {
+                              console.warn(error);
+                            });
+                        }
+                      }}
+                    >
+                      Restore
+                    </Button>
+                  </List.Content>
+                  {t.idMedia > 0 && (
+                    <Image
+                      alt={t.name}
+                      key={t.idMedia}
+                      src={getImageUrl(t.idMedia, null, 50)}
+                      onError={(i) =>
+                        (i.target.src = "/png/video_placeholder.png")
+                      }
+                      rounded
+                    />
+                  )}
+                  <List.Content>
+                    <List.Header>{t.name}</List.Header>
+                    <List.Description>
+                      {label + " deleted by " + t.by + " (" + t.when + ")"}
+                    </List.Description>
+                  </List.Content>
+                </List.Item>
+              );
+            })}
+          </List>
+        )}
+      </Segment>
+    </>
+  );
 };
 
 export default Trash;


### PR DESCRIPTION
Introduce an `AuthContainer` component to centralize the gate-keeping logic ("is this user logged in? do they have the right permissions?") which was previously scattered throughout the app and duplicated onto each page.

As a bonus, this makes it easier to see which routes need which permissions, by looking at the static declarations in `AppRoutes`.