### PR TITLE
Set the Sentry environment

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,11 +18,9 @@ Sentry.init({
     }),
     new Sentry.Replay(),
   ],
+  environment: process.env.REACT_APP_ENV ?? "unknown",
   // Performance Monitoring
   tracesSampleRate: process.env.REACT_APP_ENV === "production" ? 0.5 : 1.0,
-  // Session Replay
-  replaysSessionSampleRate:
-    process.env.REACT_APP_ENV === "production" ? 0.1 : 1.0,
   replaysOnErrorSampleRate: 1.0,
 });
 


### PR DESCRIPTION
Set the `environment` part of Sentry to correctly classify errors (errors for developers shouldn't be grouped with errors in production).

This also turns off replays for non-error sessions, as I don't think we need those.