### PR TITLE
Use Helmet's titleTemplate to templatize the titles

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -57,7 +57,7 @@ const About = () => {
   return (
     <>
       <Helmet>
-        <title>About | {meta.title}</title>
+        <title>About</title>
         <meta
           name="description"
           content="History, information and administrators."

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -375,9 +375,7 @@ const Area = () => {
   return (
     <>
       <Helmet>
-        <title>
-          {data[0].name} | {meta.title}
-        </title>
+        <title>{data[0].name}</title>
         <meta name="description" content={data[0].comment}></meta>
       </Helmet>
       <div style={{ marginBottom: "5px" }}>

--- a/src/components/AreaEdit.tsx
+++ b/src/components/AreaEdit.tsx
@@ -167,9 +167,7 @@ const AreaEdit = () => {
   return (
     <>
       <Helmet>
-        <title>
-          Edit {data.name} | {meta.title}
-        </title>
+        <title>Edit {data.name}</title>
       </Helmet>
       <Message
         size="tiny"

--- a/src/components/Areas.tsx
+++ b/src/components/Areas.tsx
@@ -115,11 +115,11 @@ const Areas = () => {
   return (
     <>
       <Helmet>
-        <title>Areas | {meta.title}</title>
+        <title>Areas</title>
         <meta
           name="description"
           content={`${data.length} areas for climbing.`}
-        ></meta>
+        />
       </Helmet>
       <Segment>
         <ButtonGroup floated="right" size="mini">

--- a/src/components/Dangerous.tsx
+++ b/src/components/Dangerous.tsx
@@ -19,7 +19,7 @@ const Dangerous = () => {
   return (
     <>
       <Helmet>
-        <title>Dangerous | {meta.title}</title>
+        <title>Dangerous</title>
         <meta name="description" content={description}></meta>
       </Helmet>
       <Segment>

--- a/src/components/Donations.tsx
+++ b/src/components/Donations.tsx
@@ -5,7 +5,7 @@ import { Segment, Header, Icon } from "semantic-ui-react";
 const Donations = () => {
   return (
     <>
-      <Helmet>
+      <Helmet titleTemplate={undefined}>
         <title>Donations</title>
         <meta name="description" content="Donations" />
       </Helmet>

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -172,7 +172,7 @@ const Filter = () => {
   return (
     <>
       <Helmet>
-        <title>{meta.title} | Filter</title>
+        <title>Filter</title>
         <meta
           name="description"
           content="Filter on routes/boulders by grade and metadata."

--- a/src/components/Frontpage.tsx
+++ b/src/components/Frontpage.tsx
@@ -24,7 +24,6 @@ const Frontpage = () => {
     <>
       {frontpage && (
         <Helmet>
-          <title>{meta.title}</title>
           <meta name="description" content={description}></meta>
         </Helmet>
       )}

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -18,7 +18,7 @@ const Graph = () => {
   return (
     <>
       <Helmet>
-        <title>Graph | {meta.title}</title>
+        <title>Graph</title>
         <meta name="description" content={description}></meta>
       </Helmet>
       <Segment>

--- a/src/components/Permissions.tsx
+++ b/src/components/Permissions.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { Loading, LockSymbol } from "./common/widgets/widgets";
-import { useMeta } from "./common/meta";
 import { getPermissions, postPermissions } from "../api";
 import {
   Header,
@@ -16,7 +15,6 @@ import { useAuth0 } from "@auth0/auth0-react";
 
 const Permissions = () => {
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const meta = useMeta();
   const [accessToken, setAccessToken] = useState<any>(null);
   const [data, setData] = useState<any>(null);
 
@@ -37,7 +35,7 @@ const Permissions = () => {
   return (
     <>
       <Helmet>
-        <title>Permissions | {meta.title}</title>
+        <title>Permissions</title>
       </Helmet>
       <Segment>
         <Header as="h2">

--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -4,7 +4,7 @@ import { Segment, Header, Icon, List } from "semantic-ui-react";
 const PrivacyPolicy = () => {
   return (
     <>
-      <Helmet>
+      <Helmet titleTemplate={undefined}>
         <title>Privacy Policy</title>
         <meta name="description" content="Privacy Policy" />
       </Helmet>

--- a/src/components/Problem/Problem.tsx
+++ b/src/components/Problem/Problem.tsx
@@ -216,7 +216,9 @@ export const Problem = () => {
   return (
     <>
       <Helmet>
-        <title>{`${data.name} [${data.grade}] (${data.areaName} / ${data.sectorName}) | ${meta.title}`}</title>
+        <title>
+          {data.name} [{data.grade}] ({data.areaName} / {data.sectorName})
+        </title>
         <meta name="description" content={data.comment}></meta>
       </Helmet>
       {tickModal}

--- a/src/components/ProblemEdit.tsx
+++ b/src/components/ProblemEdit.tsx
@@ -313,9 +313,7 @@ const ProblemEdit = () => {
   return (
     <>
       <Helmet>
-        <title>
-          Edit {data.name} | {meta.title}
-        </title>
+        <title>Edit {data.name}</title>
       </Helmet>
       <Message
         size="tiny"

--- a/src/components/Problems.tsx
+++ b/src/components/Problems.tsx
@@ -39,9 +39,7 @@ const Problems = () => {
   return (
     <>
       <Helmet>
-        <title>
-          {title} | {meta.title}
-        </title>
+        <title>{title}</title>
         <meta name="description" content={description}></meta>
       </Helmet>
       <Segment>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -91,7 +91,7 @@ const Profile = () => {
     <>
       <Helmet>
         <title>
-          {profile.firstname} {profile.lastname} | {meta.title}
+          {profile.firstname} {profile.lastname}
         </title>
         <meta
           name="description"

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -316,7 +316,7 @@ const Sector = () => {
     <>
       <Helmet>
         <title>
-          {data.name} ({data.areaName}) | {meta.title}
+          {data.name} ({data.areaName})
         </title>
         <meta name="description" content={data.comment}></meta>
       </Helmet>

--- a/src/components/SectorEdit.tsx
+++ b/src/components/SectorEdit.tsx
@@ -324,9 +324,7 @@ const SectorEdit = () => {
   return (
     <>
       <Helmet>
-        <title>
-          Edit {data.name} | {meta.title}
-        </title>
+        <title>Edit {data.name}</title>
       </Helmet>
       <Message
         size="tiny"

--- a/src/components/Sites.tsx
+++ b/src/components/Sites.tsx
@@ -76,7 +76,7 @@ const Sites = () => {
   return (
     <>
       <Helmet>
-        <title>Sites | {meta.title}</title>
+        <title>Sites</title>
         <meta name="description" content={description}></meta>
       </Helmet>
       <Segment>

--- a/src/components/Ticks.tsx
+++ b/src/components/Ticks.tsx
@@ -4,7 +4,6 @@ import { Segment, Header, Pagination, Loader, Feed } from "semantic-ui-react";
 import { Loading, LockSymbol } from "./common/widgets/widgets";
 import { Link, useParams, useNavigate } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
-import { useMeta } from "./common/meta";
 import { getTicks } from "../api";
 
 const Ticks = () => {
@@ -13,7 +12,6 @@ const Ticks = () => {
   const [loading, setLoading] = useState(false);
   const { page } = useParams();
   const navigate = useNavigate();
-  const meta = useMeta();
   useEffect(() => {
     setLoading(true);
     const update = async () => {
@@ -34,7 +32,7 @@ const Ticks = () => {
   return (
     <>
       <Helmet>
-        <title>Ticks | {meta.title}</title>
+        <title>Ticks</title>
       </Helmet>
       <Segment>
         <div>

--- a/src/components/Trash.tsx
+++ b/src/components/Trash.tsx
@@ -1,13 +1,11 @@
 import { Helmet } from "react-helmet";
 import { Loading } from "./common/widgets/widgets";
-import { useMeta } from "./common/meta";
 import { getImageUrl, useData, putTrash, useAccessToken } from "../api";
 import { Segment, Icon, Header, List, Button, Image } from "semantic-ui-react";
 import { useNavigate } from "react-router-dom";
 
 const Trash = () => {
   const accessToken = useAccessToken();
-  const meta = useMeta();
   const { data } = useData(`/trash`);
   const navigate = useNavigate();
 
@@ -18,7 +16,7 @@ const Trash = () => {
   return (
     <>
       <Helmet>
-        <title>Trash | {meta.title}</title>
+        <title>Trash</title>
       </Helmet>
       <Segment>
         <Header as="h2">

--- a/src/components/Webcams.tsx
+++ b/src/components/Webcams.tsx
@@ -41,7 +41,7 @@ const Webcams = () => {
   return (
     <>
       <Helmet>
-        <title>Webcams | {meta.title}</title>
+        <title>Webcams</title>
         <meta name="description" content={description}></meta>
       </Helmet>
       <Segment>

--- a/src/components/common/meta/meta.tsx
+++ b/src/components/common/meta/meta.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext } from "react";
 import { useData } from "../../../api";
+import { Helmet } from "react-helmet";
 
 type Grade = {
   id: number;
@@ -62,6 +63,10 @@ export const MetaProvider = ({ children }: Props) => {
 
   return (
     <MetaContext.Provider value={meta || DEFAULT_VALUE}>
+      <Helmet
+        titleTemplate={`%s | ${meta?.title}`}
+        defaultTitle={meta?.title ?? "Loading ..."}
+      />
       {children}
     </MetaContext.Provider>
   );


### PR DESCRIPTION
Virtually all of the pages used the same title format:

    some string | {meta.name}

This was replicated on every individual page. Instead, we can utilize the `titleTemplate` prop from `Helmet` and save ourselves the construction on every page.

On the few pages which didn't use this, the `titleTemplate` was overridden.