### PR TITLE
Don't open problems in a new window/tab

### DIFF
--- a/src/components/common/SmartLink/SmartLink.tsx
+++ b/src/components/common/SmartLink/SmartLink.tsx
@@ -1,0 +1,22 @@
+import React, { ComponentProps } from "react";
+import { Link } from "react-router-dom";
+import { getBaseUrl } from "../../../api";
+
+type Props = Omit<ComponentProps<typeof Link>, "to"> & { to: string };
+
+const isLocal = (url: string) => url.startsWith(getBaseUrl());
+
+const cleanUrl = (url: string) => {
+  if (isLocal(url)) {
+    return url.substring(getBaseUrl().length);
+  }
+  return url;
+};
+
+export const SmartLink = React.forwardRef<HTMLAnchorElement, Props>(
+  ({ to, ...props }, ref) => {
+    const rel = isLocal(to) ? props.rel : `${props.rel} noopener noreferrer`;
+    return <Link {...props} to={cleanUrl(to)} ref={ref} rel={rel} />;
+  }
+);
+SmartLink.displayName = "SmartLink";

--- a/src/components/common/SmartLink/index.ts
+++ b/src/components/common/SmartLink/index.ts
@@ -1,0 +1,1 @@
+export { SmartLink } from "./SmartLink";

--- a/src/components/common/profile/profile-todo.tsx
+++ b/src/components/common/profile/profile-todo.tsx
@@ -4,19 +4,12 @@ import Leaflet from "../../common/leaflet/leaflet";
 import { Loading, LockSymbol } from "../../common/widgets/widgets";
 import { List, Segment } from "semantic-ui-react";
 import { useProfileTodo } from "../../../api";
+import { SmartLink } from "../SmartLink";
 
 type ProfileTodoProps = {
   userId: number;
   defaultCenter: { lat: number; lng: number };
   defaultZoom: number;
-};
-
-const cleanUrl = (url: string) => {
-  const origin = process.env.REACT_APP_API_URL || window.location.origin;
-  if (url.startsWith(origin)) {
-    return url.substring(origin.length);
-  }
-  return url;
 };
 
 const ProfileTodo = ({
@@ -73,7 +66,7 @@ const ProfileTodo = ({
           {data.areas.map((area) => (
             <List.Item key={area.id}>
               <List.Header>
-                <Link to={cleanUrl(area.url)}>{area.name}</Link>
+                <SmartLink to={area.url}>{area.name}</SmartLink>
                 <LockSymbol
                   lockedAdmin={area.lockedAdmin}
                   lockedSuperadmin={area.lockedSuperadmin}
@@ -82,7 +75,7 @@ const ProfileTodo = ({
               {area.sectors.map((sector) => (
                 <List.List key={sector.id}>
                   <List.Header>
-                    <Link to={cleanUrl(sector.url)}>{sector.name}</Link>
+                    <SmartLink to={sector.url}>{sector.name}</SmartLink>
                     <LockSymbol
                       lockedAdmin={sector.lockedAdmin}
                       lockedSuperadmin={sector.lockedSuperadmin}
@@ -93,9 +86,9 @@ const ProfileTodo = ({
                       <List.Item key={problem.id}>
                         <List.Header>
                           {`#${problem.nr} `}
-                          <Link to={cleanUrl(problem.url)}>
+                          <SmartLink to={problem.url}>
                             {problem.name}
-                          </Link>{" "}
+                          </SmartLink>{" "}
                           {problem.grade}
                           {problem.partners && problem.partners.length > 0 && (
                             <small>


### PR DESCRIPTION
Our telemetry shows that the slowest page (on average, 95th percentile)
to laod is `/problem/*`. Virtually all of the sessions that are slowest
begin with a pageload event -- someone is navigating directly to
`/problem/:problemId`.

One possibility is that they're being sent links or clicking on
bookmarks. This is possible (and, indeed, probable).

Another possibility to enter this flow is from the `/problems` page.
From here, navigating to any problem opens a new tab -- which requires
reloading all of the network-fetched resources. Static assets like CSS,
HTML, and JS are cached. However, the lazily-loaded content is not
fetched.

This change makes the problems default to opening in the same tab. With
the new data layer, this makes navigation forward and backward much less
costly. If someone wishes to open a problem in a new tab, they can
easily do so with whatever mechanism their browser provides.