### PR TITLE
Fix issues with media on profiles

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -75,12 +75,14 @@ const Profile = () => {
     content = <ProfileSettings userRegions={profile.userRegions} />;
   }
 
+  const firstLast = [profile.firstname, profile.lastname]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <>
       <Helmet>
-        <title>
-          {profile.firstname} {profile.lastname}
-        </title>
+        <title>{firstLast}</title>
         <meta
           name="description"
           content="Profile with public ascents, media, and other statistics."
@@ -88,9 +90,7 @@ const Profile = () => {
       </Helmet>
       <Header as="h5" textAlign="center" className="buldreinfo-visible-mobile">
         {profile.picture && <Image circular src={profile.picture} />}
-        <Header.Content>
-          {profile.firstname} {profile.lastname}
-        </Header.Content>
+        <Header.Content>{firstLast}</Header.Content>
       </Header>
       <Menu pointing icon="labeled" size="mini">
         <Menu.Item header className="buldreinfo-hidden-mobile">
@@ -98,8 +98,12 @@ const Profile = () => {
             {profile.picture && <Image circular src={profile.picture} />}
             <Header.Content>
               {profile.firstname}
-              <br />
-              {profile.lastname}
+              {profile.lastname && (
+                <>
+                  <br />
+                  {profile.lastname}
+                </>
+              )}
             </Header.Content>
           </Header>
         </Menu.Item>


### PR DESCRIPTION
There are two issues fixed here:

 1. When navigating to a profile for a user that doesn't have both first and last names provided, the UI can break because `undefined` is attempted to be rendered in the `<title>`, which React is unhappy about.
 2. If the media item hasn't been loaded yet (eg, a direct link to the media item) then `NaN` will be computed as the seek-to amount, and this isn't allowed.

Not to put any profile on blast, this particular URL has both of these problems and makes a great test case: https://buldreinfo.com/user/2615/media