### PR TITLE
Do a lazy-load with fallback

### DIFF
--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -1,71 +1,115 @@
-import React, { lazy, Suspense, useLayoutEffect } from "react";
+import React, { Suspense, useLayoutEffect } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { Loading } from "./common/widgets/widgets";
+import { lazy } from "../utils/lazyRetry";
 
 const AuthContainer = lazy(
   () => import(/* webpackChunkName: "auth" */ "./AuthContainer"),
+  "auth",
 );
-
-const About = lazy(() => import(/* webpackChunkName: "about" */ "./About"));
-const Area = lazy(() => import(/* webpackChunkName: "area" */ "./Area"));
+const About = lazy(
+  () => import(/* webpackChunkName: "about" */ "./About"),
+  "about",
+);
+const Area = lazy(
+  () => import(/* webpackChunkName: "area" */ "./Area"),
+  "area",
+);
 const AreaEdit = lazy(
   () => import(/* webpackChunkName: "area-edit" */ "./AreaEdit"),
+  "area-edit",
 );
-const Areas = lazy(() => import(/* webpackChunkName: "areas" */ "./Areas"));
+const Areas = lazy(
+  () => import(/* webpackChunkName: "areas" */ "./Areas"),
+  "areas",
+);
 const Dangerous = lazy(
   () => import(/* webpackChunkName: "dangerous" */ "./Dangerous"),
+  "dangerous",
 );
 const Donations = lazy(
   () => import(/* webpackChunkName: "donations" */ "./Donations"),
+  "donations",
 );
 const Frontpage = lazy(
   () =>
     import(
       /* webpackPrefetch: true, webpackChunkName: "frontpage" */ "./Frontpage"
     ),
+  "frontpage",
 );
-const Filter = lazy(() => import(/* webpackChunkName: "filter" */ "./Filter"));
-const Graph = lazy(() => import(/* webpackChunkName: "graph" */ "./Graph"));
+const Filter = lazy(
+  () => import(/* webpackChunkName: "filter" */ "./Filter"),
+  "filter",
+);
+const Graph = lazy(
+  () => import(/* webpackChunkName: "graph" */ "./Graph"),
+  "graph",
+);
 const MediaSvgEdit = lazy(
   () => import(/* webpackChunkName: "media-svg-edit" */ "./MediaSvgEdit"),
+  "media-svg-edit",
+);
+const Permissions = lazy(
+  () => import(/* webpackChunkName: "permissions" */ "./Permissions"),
+  "permissions",
 );
 const PrivacyPolicy = lazy(
   () => import(/* webpackChunkName: "privacy-policy" */ "./PrivacyPolicy"),
+  "privacy-policy",
 );
 const Problem = lazy(
   () => import(/* webpackChunkName: "problem" */ "./Problem"),
+  "problem",
 );
 const ProblemEdit = lazy(
   () => import(/* webpackChunkName: "problem-edit" */ "./ProblemEdit"),
+  "problem-edit",
 );
 const ProblemEditMedia = lazy(
   () =>
     import(/* webpackChunkName: "problem-edit-media" */ "./ProblemEditMedia"),
+  "problem-edit-media",
 );
 const Problems = lazy(
   () => import(/* webpackChunkName: "problems" */ "./Problems"),
+  "problems",
 );
 const Profile = lazy(
   () => import(/* webpackChunkName: "profile" */ "./Profile"),
+  "profile",
 );
-const Sector = lazy(() => import(/* webpackChunkName: "sector" */ "./Sector"));
+const Sector = lazy(
+  () => import(/* webpackChunkName: "sector" */ "./Sector"),
+  "sector",
+);
 const SectorEdit = lazy(
   () => import(/* webpackChunkName: "sector-edit" */ "./SectorEdit"),
+  "sector-edit",
 );
-const Sites = lazy(() => import(/* webpackChunkName: "sites" */ "./Sites"));
+const Sites = lazy(
+  () => import(/* webpackChunkName: "sites" */ "./Sites"),
+  "sites",
+);
 const SvgEdit = lazy(
   () => import(/* webpackChunkName: "svg-edit" */ "./SvgEdit"),
+  "svg-edit",
 );
 const Swagger = lazy(
   () => import(/* webpackChunkName: "swagger" */ "./Swagger"),
+  "swagger",
 );
-const Ticks = lazy(() => import(/* webpackChunkName: "ticks" */ "./Ticks"));
-const Trash = lazy(() => import(/* webpackChunkName: "trash" */ "./Trash"));
-const Permissions = lazy(
-  () => import(/* webpackChunkName: "permissions" */ "./Permissions"),
+const Ticks = lazy(
+  () => import(/* webpackChunkName: "ticks" */ "./Ticks"),
+  "ticks",
+);
+const Trash = lazy(
+  () => import(/* webpackChunkName: "trash" */ "./Trash"),
+  "trash",
 );
 const Webcams = lazy(
   () => import(/* webpackChunkName: "webcams" */ "./Webcams"),
+  "webcams",
 );
 
 function AppRoutes() {

--- a/src/utils/lazyRetry.ts
+++ b/src/utils/lazyRetry.ts
@@ -1,0 +1,75 @@
+import { lazy as reactLazy } from "react";
+import * as Sentry from "@sentry/react";
+import { Extras } from "@sentry/types";
+
+/**
+ * This was heavily inspired by this blog post: https://www.codemzy.com/blog/fix-chunkloaderror-react
+ */
+const lazyRetry = function (
+  componentImport: Parameters<typeof reactLazy>[0],
+  componentName: string,
+) {
+  const key = `retry-lazy-refreshed/${componentName}`;
+
+  return new Promise<Awaited<ReturnType<typeof componentImport>>>(
+    (resolve, reject) => {
+      const refreshTime: number = (() => {
+        const data = window.sessionStorage.getItem(key);
+        if (!data) {
+          return 0;
+        }
+
+        const timestamp = +data;
+        if (Number.isNaN(timestamp)) {
+          return 0;
+        }
+
+        return timestamp;
+      })();
+
+      componentImport()
+        .then((component) => {
+          window.sessionStorage.removeItem(key);
+          resolve(component);
+        })
+        .catch((error) => {
+          if (refreshTime) {
+            const extra: Extras = {
+              componentName,
+            };
+
+            for (let i = 0; i < sessionStorage.length; i += 1) {
+              const itemKey = sessionStorage.key(i);
+              if (!itemKey.startsWith("retry-lazy-refreshed/")) {
+                continue;
+              }
+
+              extra[itemKey] = sessionStorage.getItem(itemKey);
+            }
+
+            Sentry.captureException(error, {
+              extra,
+            });
+            reject(error);
+          } else {
+            Sentry.captureMessage("Failed to load chunk", {
+              extra: {
+                componentName,
+                error,
+              },
+            });
+            window.sessionStorage.setItem(key, String(Date.now())); // we are now going to refresh
+            window.location.reload(); // refresh the page
+            return { default: () => null };
+          }
+        });
+    },
+  );
+};
+
+export const lazy = function (
+  componentImport: Parameters<typeof reactLazy>[0],
+  componentName: string,
+) {
+  return reactLazy(() => lazyRetry(componentImport, componentName));
+};


### PR DESCRIPTION
Do a lazy-load with fallback

When the app is built, it's split into several different chunks, in
order to reduce initial load time (downloading and parsing ≥ 3MB of
JavaScript can be very taxing for some networks and browsers). However,
this creates issues when deploying new versions, as these chunk names
are hashed and change for almost every build.

This means that if a user is using the app, and the CI/CD process
deploys a new version, they might be hit with an error screen when they
browse to a new page. This is very uncool.

What this change does is watch the chunk-loading process and, if that
fails, reloads the page. This should be enough to allow the user to
recover, as they'll get a fresh set of chunk-pointers loaded when the
newly-deployed app is loaded. It's not a _great_ experience, but is
hopefully better than crashes.

 ## Testing

To test that this works, I did the following:

1. `yarn build` to generate a production bundle
2. `npx serve build` to get a local server up and running
3. Navigate to <http://localhost:3000> to load the app
4. In another terminal, `rm build/static/chunk-about-*` to delete the
   chunk for the "About" page
5. Click "About" in the header

At this point, the app will:

1. Attempt to load the `/static/chunk-about-*` resource
2. Fail to load that resource
3. Put a marker into `sessionStorage`
4. Reload the page
   1. (NOTE: you'll be left on an error page because the `serve` package
      doesn't do SPA routing correctly)

After that, I:

1. Went to <http://localhost:3000> to get the app loaded again
2. Clicked "About" again

At this point, the app will:

1. Attempt to laod the `/static/chunk-about-*` resource
2. Fail to load that resource (again)
3. See that we've failed to load that previously
4. Show an error message (to prevent a refresh-loop)
