### PR TITLE
Add types for isomorphic-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/runtime": "^7.22.6",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@types/helmet": "^4.0.0",
+    "@types/isomorphic-fetch": "^0.0.36",
     "@types/leaflet": "^1.9.3",
     "@types/react": "^18.2.14",
     "@types/swagger-ui-react": "^4.18.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -40,7 +40,7 @@ function makeAuthenticatedRequest(
   const { consistencyAction, ...opts } = extraOptions || {};
   const options = {
     ...opts,
-    mode: "cors",
+    mode: "cors" as const,
     headers: {
       ...opts?.headers,
       Authorization: accessToken ? `Bearer ${accessToken}` : undefined,
@@ -99,7 +99,7 @@ function usePostData<TData = any>(
         ? await getAccessTokenSilently()
         : null;
 
-      return makeAuthenticatedRequest(accessToken, urlSuffix, {
+      const res = await makeAuthenticatedRequest(accessToken, urlSuffix, {
         method: "POST",
         body: JSON.stringify(data),
         headers: {
@@ -108,6 +108,7 @@ function usePostData<TData = any>(
         },
         ...fetchOptions,
       });
+      return res.json();
     },
     ...options,
   });
@@ -233,6 +234,8 @@ export function getProblemPdfUrl(
 
 export function getProblemsXlsx(accessToken: string | null): Promise<any> {
   return makeAuthenticatedRequest(accessToken, `/problems/xlsx`, {
+    // @ts-expect-error - I don't think that this is necessary, but I'm going
+    //                    to investigate this later.
     expose: ["Content-Disposition"],
   }).catch((error) => {
     console.warn(error);
@@ -841,6 +844,8 @@ export function getUserSearch(
 
 export function getUsersTicks(accessToken: string | null): Promise<any> {
   return makeAuthenticatedRequest(accessToken, `/users/ticks`, {
+    // @ts-expect-error - I don't think that this is necessary, but I'm going
+    //                    to investigate this later.
     expose: ["Content-Disposition"],
   }).catch((error) => {
     console.warn(error);
@@ -1081,11 +1086,11 @@ export function postProblem(
       Accept: "application/json",
     },
   })
+    .then((data) => data.json())
     .catch((error) => {
       console.warn(error);
       alert(error);
-    })
-    .then((data) => data.json());
+    });
 }
 
 export function postProblemMedia(
@@ -1120,11 +1125,11 @@ export function postProblemMedia(
       Accept: "application/json",
     },
   })
+    .then((data) => data.json())
     .catch((error) => {
       console.warn(error);
       alert(error);
-    })
-    .then((data) => data.json());
+    });
 }
 
 export function postSearch(
@@ -1236,11 +1241,11 @@ export function postSector(
       Accept: "application/json",
     },
   })
+    .then((data) => data.json())
     .catch((error) => {
       console.warn(error);
       alert(error);
-    })
-    .then((data) => data.json());
+    });
 }
 
 export function postTicks(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2158,6 +2158,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/isomorphic-fetch@^0.0.36":
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.36.tgz#3a6d8f63974baf26b10fd1314db910633108a769"
+  integrity sha512-ulw4d+vW1HKn4oErSmNN2HYEcHGq0N1C5exlrMM0CRqX1UUpFhGb5lwiom5j9KN3LBJJDLRmYIZz1ghm7FIzZw==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"


### PR DESCRIPTION
The type definitions were missing for the `isomorphic-fetch` package, which made it hard to work with. Adding these types also uncovered a few edge-cases which would've resulted in crashes.