### PR TITLE
Rework the trash page

### DIFF
--- a/src/@types/buldreinfo/index.d.ts
+++ b/src/@types/buldreinfo/index.d.ts
@@ -91,3 +91,14 @@ type ProfileStatistics = {
   orderByGrade: boolean;
   ticks: Tick[];
 };
+
+type Trash = {
+  idMedia: number;
+  name: string;
+  when: string;
+  by: string;
+} & (
+  | { idArea: number; idSector: 0; idProblem: 0 }
+  | { idArea: 0; idSector: number; idProblem: 0 }
+  | { idArea: 0; idSector: 0; idProblem: number }
+);


### PR DESCRIPTION
Update the trash page (`/trash`) to use the mutations & queries pattern. This is a rather pointless change, but it provided an opportunity to fix up the typing around `usePostData(..)` and `useData(..)`, which was a bit hodge-podge.

This also fixes a small error wherein we trigger fetches of known-deleted resources when a problem is moved to the trash (we should apply this pattern to other media types, too).