### PR TITLE
Don't invalidate everything for a search query

### DIFF
--- a/src/@types/buldreinfo/index.d.ts
+++ b/src/@types/buldreinfo/index.d.ts
@@ -102,3 +102,15 @@ type Trash = {
   | { idArea: 0; idSector: number; idProblem: 0 }
   | { idArea: 0; idSector: 0; idProblem: number }
 );
+
+type SearchResult = {
+  url?: string;
+  externalurl?: string;
+  mediaid?: string;
+  mediaurl?: string;
+  crc32: string;
+  title: string;
+  description: string;
+  lockedadmin: boolean;
+  lockedsuperadmin: boolean;
+};

--- a/src/api.ts
+++ b/src/api.ts
@@ -98,7 +98,10 @@ function usePostData<TVariables, TData = Response>(
     UseMutationOptions<TData, unknown, TVariables> & {
       fetchOptions: FetchOptions;
       createUrl: (variables: TVariables) => string;
-      select: (response: Response, variables: TVariables) => TData;
+      select: (
+        response: Response,
+        variables: TVariables,
+      ) => TData | Promise<TData>;
     }
   > = {},
 ) {
@@ -1152,6 +1155,22 @@ export function postProblemMedia(
       console.warn(error);
       alert(error);
     });
+}
+
+export function useSearch() {
+  const { mutateAsync, data, ...rest } = usePostData<
+    { value: string },
+    SearchResult[]
+  >(`/search`, {
+    select(response) {
+      return response.json();
+    },
+    fetchOptions: {
+      consistencyAction: "nop",
+    },
+  });
+
+  return { search: mutateAsync, ...rest, data: data ?? [] };
 }
 
 export function postSearch(


### PR DESCRIPTION
Searches use POST (rather than the more-common GET) request, and we requery everything on mutations (by default) to ensure cache consistency. However, this means that searching does a _ton_ of revalidation.

Disable this behavior when searching .. and make some searchbox cleanups along the way.