### PR TITLE
Don't crash on failing profile data

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -52,12 +52,7 @@ const Profile = () => {
   let content = null;
   if (activePage === Page.user) {
     content = (
-      <ProfileStatistics
-        userId={profile.id}
-        canDownload={loggedInProfile}
-        defaultCenter={meta.defaultCenter}
-        defaultZoom={meta.defaultZoom}
-      />
+      <ProfileStatistics userId={profile.id} canDownload={loggedInProfile} />
     );
   } else if (activePage === Page.todo) {
     content = (


### PR DESCRIPTION
It's possible for the profile data to fail to load - I don't know how, but we have at least one crash in the wild that happened. If this happens, let's record the failure (so that we can investigate) and show the user a friendly error message instead of crashing the app.