### PR TITLE
Standardize the header button pattern

### DIFF
--- a/src/components/Areas.tsx
+++ b/src/components/Areas.tsx
@@ -1,14 +1,7 @@
 import React, { useState, useRef } from "react";
 import { Helmet } from "react-helmet";
 import { Link, useNavigate } from "react-router-dom";
-import {
-  Header,
-  Button,
-  List,
-  Icon,
-  Segment,
-  ButtonGroup,
-} from "semantic-ui-react";
+import { Button, List, Icon, Segment } from "semantic-ui-react";
 import Leaflet from "./common/leaflet/leaflet";
 import ChartGradeDistribution from "./common/chart-grade-distribution/chart-grade-distribution";
 import { Loading, LockSymbol } from "./common/widgets/widgets";
@@ -16,6 +9,7 @@ import { useAreas } from "../api";
 import { Remarkable } from "remarkable";
 import { linkify } from "remarkable/linkify";
 import { useMeta } from "./common/meta";
+import { HeaderButtons } from "./common/HeaderButtons";
 
 const Areas = () => {
   const { data } = useAreas();
@@ -122,7 +116,11 @@ const Areas = () => {
         />
       </Helmet>
       <Segment>
-        <ButtonGroup floated="right" size="mini">
+        <HeaderButtons
+          header="Areas"
+          subheader={data.length ? `${data.length} areas` : ""}
+          icon="list"
+        >
           <Button
             active={!showForDevelopers}
             onClick={() => setShowForDevelopers(false)}
@@ -143,14 +141,7 @@ const Areas = () => {
               </Button.Content>
             </Button>
           )}
-        </ButtonGroup>
-        <Header as="h2">
-          <Icon name="list" />
-          <Header.Content>
-            Areas
-            <Header.Subheader>{data.length} areas</Header.Subheader>
-          </Header.Content>
-        </Header>
+        </HeaderButtons>
         <List celled link horizontal size="small">
           {data
             .filter((a) => a.forDevelopers === showForDevelopers)

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -20,7 +20,6 @@ export const Navigation = () => {
             display: "flex",
             flexDirection: "row",
             flex: 1,
-            paddingRight: "20px",
           }}
           className="row-1"
         >

--- a/src/components/Problems/Problems.tsx
+++ b/src/components/Problems/Problems.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 import {
-  Header,
   Segment,
   Icon,
   Button,
@@ -16,6 +15,7 @@ import { saveAs } from "file-saver";
 import TableOfContents from "../common/TableOfContents";
 import { useFilterState } from "./reducer";
 import { FilterContext, FilterForm } from "../common/FilterForm";
+import { HeaderButtons } from "../common/HeaderButtons";
 
 type Props = { filterOpen?: boolean };
 
@@ -114,7 +114,11 @@ export const Problems = ({ filterOpen }: Props) => {
 
   const preamble = (
     <>
-      <ButtonGroup size="mini" floated="right">
+      <HeaderButtons
+        header={title}
+        subheader={totalDescription}
+        icon="database"
+      >
         <Button
           labelPosition="left"
           icon
@@ -149,19 +153,11 @@ export const Problems = ({ filterOpen }: Props) => {
           <Icon name="file excel" />
           Download
         </Button>
-      </ButtonGroup>
-      <Header as="h2">
-        <Icon name="database" />
-        <Header.Content>
-          {title}
-          <Header.Subheader>{totalDescription}</Header.Subheader>
-        </Header.Content>
-      </Header>
+      </HeaderButtons>
       {visible && (
         <>
           <Divider />
           <FilterForm />
-          <Divider />
         </>
       )}
       {!visible && filteredProblems > 0 && (

--- a/src/components/common/FilterForm/FilterForm.tsx
+++ b/src/components/common/FilterForm/FilterForm.tsx
@@ -4,8 +4,6 @@ import {
   Header,
   Checkbox,
   Button,
-  Container,
-  ButtonGroup,
   Icon,
   Divider,
 } from "semantic-ui-react";
@@ -13,6 +11,7 @@ import { GradeSelect } from "./GradeSelect";
 import { getLocales } from "../../../api";
 import { useMeta } from "../meta";
 import { useFilter } from "./context";
+import { HeaderButtons } from "../HeaderButtons";
 
 const CLIMBING_OPTIONS = [
   {
@@ -45,38 +44,26 @@ export const FilterForm = () => {
 
   return (
     <Form>
-      <Container
-        as="div"
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          alignItems: "center",
-        }}
-      >
-        <Header as="h2" style={{ flex: 1, margin: "0" }}>
-          Filter
-        </Header>
-        <ButtonGroup size="mini">
-          {filteredProblems > 0 && (
-            <Button
-              icon
-              labelPosition="left"
-              onClick={() => dispatch({ action: "reset" })}
-            >
-              <Icon name="trash alternate outline" />
-              Clear filter
-            </Button>
-          )}
+      <HeaderButtons header="Filter">
+        {filteredProblems > 0 && (
           <Button
             icon
             labelPosition="left"
-            onClick={() => dispatch({ action: "close-filter" })}
+            onClick={() => dispatch({ action: "reset" })}
           >
-            <Icon name="close" />
-            Close
+            <Icon name="trash alternate outline" />
+            Clear filter
           </Button>
-        </ButtonGroup>
-      </Container>
+        )}
+        <Button
+          icon
+          labelPosition="left"
+          onClick={() => dispatch({ action: "close-filter" })}
+        >
+          <Icon name="close" />
+          Close
+        </Button>
+      </HeaderButtons>
       <Divider />
       <Form.Field>
         <Header as="h3">Grades</Header>

--- a/src/components/common/HeaderButtons/HeaderButtons.tsx
+++ b/src/components/common/HeaderButtons/HeaderButtons.tsx
@@ -1,0 +1,44 @@
+import React, { ComponentProps } from "react";
+import { ButtonGroup, Header, Icon } from "semantic-ui-react";
+
+type Props = {
+  icon?: ComponentProps<typeof Icon>["name"];
+  header: string;
+  subheader?: React.ReactNode;
+  children: React.ReactNode | React.ReactNode[];
+};
+
+export const HeaderButtons = ({ header, subheader, icon, children }: Props) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        flexWrap: "wrap-reverse",
+        alignItems: "flex-end",
+      }}
+    >
+      <Header as="h2" style={{ marginBottom: 0 }}>
+        {icon && <Icon name={icon} />}
+        <Header.Content>
+          {header}
+          {subheader && (
+            <Header.Subheader style={{ lineWrap: "no-wrap" }}>
+              {subheader}
+            </Header.Subheader>
+          )}
+        </Header.Content>
+      </Header>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          flexGrow: 1,
+          marginBottom: 10,
+        }}
+      >
+        <ButtonGroup size="mini">{children}</ButtonGroup>
+      </div>
+    </div>
+  );
+};

--- a/src/components/common/HeaderButtons/index.ts
+++ b/src/components/common/HeaderButtons/index.ts
@@ -1,0 +1,1 @@
+export { HeaderButtons } from "./HeaderButtons";


### PR DESCRIPTION
The header-with-buttons pattern is used in a few places, and there are some edge cases to handle when it comes to responsive layouts. This change introduces a `<HeaderButtons />` component to ensure that it's handled the same way throughout the app.

| Device | Screenshot |
|:---:|:---|
| mobile | ![image](https://github.com/jossi87/climbing-web/assets/418560/efda7934-38f2-4cae-a4a5-47b1e7c927d0) |
| wider | ![image](https://github.com/jossi87/climbing-web/assets/418560/4d282ea7-2326-45cf-8436-62de18c73723) |
| desktop | ![image](https://github.com/jossi87/climbing-web/assets/418560/db4b12f7-36ed-461c-800e-73ad73e87ccc) |

