### PR TITLE
Fix an issue with the filter not always applying

### DIFF
--- a/src/components/Problems/Problems.tsx
+++ b/src/components/Problems/Problems.tsx
@@ -161,7 +161,7 @@ export const Problems = ({ filterOpen }: Props) => {
         </>
       )}
       {!visible && filteredProblems > 0 && (
-        <Message warning raised>
+        <Message warning>
           There is an active filter which is hiding{" "}
           <strong>
             {description(

--- a/src/components/common/FilterForm/GradeSelect/GradeSelect.tsx
+++ b/src/components/common/FilterForm/GradeSelect/GradeSelect.tsx
@@ -1,25 +1,15 @@
-import React, { useMemo } from "react";
+import React from "react";
 import RangeSlider from "react-range-slider-input";
-import { useMeta } from "../../meta";
 import "react-range-slider-input/dist/style.css";
 import { useFilter } from "../context";
 import { Dropdown } from "semantic-ui-react";
+import { useGrades } from "../../meta/meta";
 
 export const GradeSelect = () => {
   const { filterGradeLow, filterGradeHigh, dispatch } = useFilter();
-  const { grades } = useMeta();
-  const [gradesLowHigh, indexMapping] = useMemo(() => {
-    const easyToHard = grades.map(({ grade }) => grade).reverse();
-    const indexMapping = easyToHard.reduce(
-      (acc, grade, i) => ({ ...acc, [grade]: i }),
-      {},
-    );
-    return [easyToHard, indexMapping];
-  }, [grades]);
+  const { easyToHard: sorted, mapping: gradeIndexMapping } = useGrades();
 
-  const max = Math.max(grades.length - 1, 0);
-  const sorted = gradesLowHigh;
-  const mapped = indexMapping;
+  const max = Math.max(sorted.length - 1, 0);
   const low = filterGradeLow || sorted[0];
   const high = filterGradeHigh || sorted[max];
 
@@ -30,13 +20,12 @@ export const GradeSelect = () => {
           key={`${0}-${max}`}
           min={0}
           max={max}
-          value={[mapped[low] ?? 0, mapped[high] ?? max]}
+          value={[gradeIndexMapping[low] ?? 0, gradeIndexMapping[high] ?? max]}
           onInput={([l, h]) => {
             dispatch({
               action: "set-grades",
               low: sorted[l] ?? sorted[0],
               high: sorted[h] ?? sorted[max],
-              gradeDifficultyLookup: indexMapping,
             });
           }}
           disabled={max === 0}
@@ -53,15 +42,14 @@ export const GradeSelect = () => {
             pointing="top left"
             options={(sorted as unknown as string[])
               .filter((label) => {
-                const rank = mapped[label];
-                return rank < (mapped[high] ?? max);
+                const rank = gradeIndexMapping[label];
+                return rank < (gradeIndexMapping[high] ?? max);
               })
               .map((label) => ({ key: label, text: label, value: label }))}
             onChange={(_, { value }) => {
               dispatch({
                 action: "set-grade",
                 low: String(value),
-                gradeDifficultyLookup: indexMapping,
               });
             }}
           />
@@ -74,15 +62,14 @@ export const GradeSelect = () => {
             pointing="top right"
             options={(sorted as unknown as string[])
               .filter((label) => {
-                const rank = mapped[label];
-                return rank > (mapped[low] ?? 0);
+                const rank = gradeIndexMapping[label];
+                return rank > (gradeIndexMapping[low] ?? 0);
               })
               .map((label) => ({ key: label, text: label, value: label }))}
             onChange={(_, { value }) => {
               dispatch({
                 action: "set-grade",
                 high: String(value),
-                gradeDifficultyLookup: indexMapping,
               });
             }}
           />

--- a/src/components/common/meta/meta.tsx
+++ b/src/components/common/meta/meta.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 import { useData } from "../../../api";
 import { Helmet } from "react-helmet";
 
@@ -66,6 +66,24 @@ export const useMeta = (): Metadata => {
     throw new Error("useMeta() can only be used inside of <MetaProvider />");
   }
   return metadata;
+};
+
+export const useGrades = () => {
+  const { grades } = useMeta();
+  const [gradesLowHigh, indexMapping] = useMemo(() => {
+    const easyToHard = grades.map(({ grade }) => grade).reverse();
+    const indexMapping = easyToHard.reduce(
+      (acc, grade, i) => ({ ...acc, [grade]: i }),
+      {},
+    );
+    return [easyToHard, indexMapping];
+  }, [grades]);
+
+  return {
+    hardToEasy: grades.map(({ grade }) => grade),
+    easyToHard: gradesLowHigh,
+    mapping: indexMapping,
+  };
 };
 
 export const MetaProvider = ({ children }: Props) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,8 +15,8 @@ Sentry.init({
     new Sentry.BrowserTracing({
       tracePropagationTargets: ["localhost", getBaseUrl()],
     }),
-    new Sentry.Replay(),
-  ],
+    process.env.REACT_APP_ENV !== "development" && new Sentry.Replay(),
+  ].filter(Boolean),
   environment: process.env.REACT_APP_ENV ?? "unknown",
   // Performance Monitoring
   tracesSampleRate: process.env.REACT_APP_ENV === "production" ? 0.5 : 1.0,


### PR DESCRIPTION
On initial load, the filter won't filter out based on grade levels. This is because the grade information is only set when the `<GradeSelect />` component is rendered .. but it's not rendered by default.

Fix this by listening for the grade information to change and always keeping the state updated.

This also introduces a `useGrades()` hook to make this information easier throughout the app (though this cleanup has not yet been performed).