### PR TITLE
Correct the admin/superadmin filter logic

### DIFF
--- a/src/components/Problems/reducer.ts
+++ b/src/components/Problems/reducer.ts
@@ -108,20 +108,18 @@ const filter = (state: State): State => {
                   }
                 }
 
-                if (filterOnlyAdmin) {
-                  const locked = problem.lockedAdmin;
-                  if (!locked) {
-                    filteredOut.problems += 1;
-                  }
-                  return locked;
-                }
-
                 if (filterOnlySuperAdmin) {
                   const locked = problem.lockedSuperadmin;
                   if (!locked) {
                     filteredOut.problems += 1;
+                    return false;
                   }
-                  return locked;
+                } else if (filterOnlyAdmin) {
+                  const locked = problem.lockedAdmin;
+                  if (!locked) {
+                    filteredOut.problems += 1;
+                    return false;
+                  }
                 }
 
                 if (


### PR DESCRIPTION
The admin & superadmin filters can be used in conjunction, and they shouldn't override each other. Additionally, they shouldn't override the other filters that might be applied (eg, grades or types).