### PR TITLE
Rework the /user/<uid>/settings page

### DIFF
--- a/src/@types/buldreinfo/index.d.ts
+++ b/src/@types/buldreinfo/index.d.ts
@@ -37,6 +37,7 @@ type Region = {
   name: string;
   enabled: boolean;
   readOnly: boolean;
+  role: string;
 };
 
 type Profile = {

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -67,7 +67,7 @@ const Profile = () => {
   } else if (activePage === Page.captured) {
     content = <ProfileMedia userId={profile.id} captured={true} />;
   } else if (activePage === Page.settings) {
-    content = <ProfileSettings userRegions={profile.userRegions} />;
+    content = <ProfileSettings />;
   }
 
   const firstLast = [profile.firstname, profile.lastname]

--- a/src/components/common/profile/profile-settings.tsx
+++ b/src/components/common/profile/profile-settings.tsx
@@ -1,72 +1,36 @@
 import React from "react";
-import { Segment, Icon, Label, Header } from "semantic-ui-react";
-import { postUserRegion, useAccessToken } from "../../../api";
-import { useNavigate } from "react-router-dom";
+import { Segment, Header, Checkbox, Form } from "semantic-ui-react";
+import { useProfile } from "../../../api";
 
-const ProfileSettings = ({ userRegions }) => {
-  const accessToken = useAccessToken();
-  const navigate = useNavigate();
-  if (!accessToken || !userRegions || userRegions.length === 0) {
+const ProfileSettings = () => {
+  const { setRegion, data } = useProfile();
+
+  if (!data?.userRegions?.length) {
     return <Segment>No data</Segment>;
   }
+
   return (
     <Segment>
       <Header as="h4">Specify the different regions you want to show</Header>
-      {userRegions.map((ur) => {
-        if (ur.enabled && ur.readOnly) {
+      <Form>
+        {data?.userRegions.map((region) => {
+          const label = region.role
+            ? `${region.name} (${region.role})`
+            : region.name;
           return (
-            <Label color="blue" key={ur.id} active={false} size="mini">
-              {ur.name}
-              <Label.Detail>{ur.role ? ur.role : "Current site"}</Label.Detail>
-            </Label>
+            <Form.Field key={region.id}>
+              <Checkbox
+                label={label}
+                checked={region.enabled}
+                disabled={region.readOnly}
+                onChange={(_, { checked }) => {
+                  setRegion({ region, del: !checked });
+                }}
+              />
+            </Form.Field>
           );
-        } else if (ur.enabled && !ur.readOnly) {
-          return (
-            <Label
-              color="blue"
-              key={ur.id}
-              active={true}
-              size="mini"
-              as="a"
-              onClick={() => {
-                postUserRegion(accessToken, ur.id, true)
-                  .then(() => {
-                    navigate(0);
-                  })
-                  .catch((error) => {
-                    console.warn(error);
-                    alert(error.toString());
-                  });
-              }}
-            >
-              {ur.name}
-              <Icon name="delete" />
-            </Label>
-          );
-        } else {
-          return (
-            <Label
-              key={ur.id}
-              active={true}
-              size="mini"
-              as="a"
-              onClick={() => {
-                postUserRegion(accessToken, ur.id, false)
-                  .then(() => {
-                    navigate(0);
-                  })
-                  .catch((error) => {
-                    console.warn(error);
-                    alert(error.toString());
-                  });
-              }}
-            >
-              <Icon name="add" />
-              {ur.name}
-            </Label>
-          );
-        }
-      })}
+        })}
+      </Form>
     </Segment>
   );
 };


### PR DESCRIPTION
The page which lets you control which regions to show under the same site was a bit annoying to use - it would reload every time something was changed, making it really flashy and awkward.

This is no longer necessary, as we can reload the data in the background. However, this change goes one step further and directly modifies the local datastore to avoid an extra round-trip -- mainly just for fun and practice :)