### PR TITLE
Make the admin/superadmin filter exclusive

### DIFF
--- a/src/components/Problems/reducer.ts
+++ b/src/components/Problems/reducer.ts
@@ -289,6 +289,7 @@ const reducer = (state: State, update: Update): State => {
       return {
         ...state,
         filterOnlyAdmin: checked,
+        filterOnlySuperAdmin: undefined,
       };
     }
 
@@ -296,6 +297,7 @@ const reducer = (state: State, update: Update): State => {
       const { checked } = update;
       return {
         ...state,
+        filterOnlyAdmin: undefined,
         filterOnlySuperAdmin: checked,
       };
     }


### PR DESCRIPTION
Toggling on the "Only admin" filter should toggle off (if set) the "Only superadmin" filter (and likewise for the other way around).