### PR TITLE
chore: Remove a console warning from SearchBox

### DIFF
--- a/src/components/common/search-box/search-box.tsx
+++ b/src/components/common/search-box/search-box.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 
 type SearchBoxProps = Omit<
   React.ComponentProps<typeof Search>,
+  | "children"
   | "id"
   | "loading"
   | "minCharacters"
@@ -16,7 +17,7 @@ type SearchBoxProps = Omit<
   | "value"
 >;
 
-const SearchBox = (searchProps: SearchBoxProps) => {
+const SearchBox = ({ children: _, ...searchProps }: SearchBoxProps) => {
   const navigate = useNavigate();
   const { search, isLoading, data } = useSearch();
 


### PR DESCRIPTION
When the `SearchBox` is rendered in the `<Menu.Item>`, it gets bogus `children` passed in. This is harmless except it prints a warning in the console and that bugs me.