### PR TITLE
chore: Add @types/file-saver

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
+    "@types/file-saver": "^2.0.5",
     "@types/helmet": "^4.0.0",
     "@types/isomorphic-fetch": "^0.0.36",
     "@types/leaflet": "^1.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,6 +2148,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/file-saver@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.5.tgz#9ee342a5d1314bb0928375424a2f162f97c310c7"
+  integrity sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==
+
 "@types/geojson@*":
   version "7946.0.8"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"


### PR DESCRIPTION
We use the `file-saver` package to serve text blobs to the user (eg, downloading Excel files). This package has types defined in the `@types/file-saver` package.