### PR TITLE
Restore search partial-query persistence

### DIFF
--- a/src/components/common/search-box/search-box.tsx
+++ b/src/components/common/search-box/search-box.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Search, Image, Icon } from "semantic-ui-react";
 import { getImageUrl, useSearch } from "./../../../api";
 import { LockSymbol } from "../widgets/widgets";
@@ -20,20 +20,27 @@ type SearchBoxProps = Omit<
 const SearchBox = ({ children: _, ...searchProps }: SearchBoxProps) => {
   const navigate = useNavigate();
   const { search, isLoading, data } = useSearch();
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    if (value.trim().length > 0) {
+      search({ value });
+    }
+  }, [search, value]);
 
   return (
     <Search
       id="mySearch"
       loading={isLoading}
-      onResultSelect={(e, { result }) =>
-        result.externalurl
-          ? window.open(result.externalurl, "_blank")
-          : navigate(result.url)
-      }
-      onSearchChange={(e, { value }) => {
-        if (value.trim().length > 0) {
-          search({ value });
+      onResultSelect={(_, { result }) => {
+        if (result.externalurl) {
+          window.open(result.externalurl, "_blank");
+        } else {
+          navigate(result.url);
         }
+      }}
+      onSearchChange={(_, { value }) => {
+        setValue(value);
       }}
       placeholder="Search"
       resultRenderer={(data) => {
@@ -113,6 +120,7 @@ const SearchBox = ({ children: _, ...searchProps }: SearchBoxProps) => {
         lockedsuperadmin: String(s.lockedsuperadmin),
       }))}
       {...searchProps}
+      value={value}
     />
   );
 };


### PR DESCRIPTION
When searching, often you get good enough results without typing the whole query. In this case, you want to be able to click on a result and go there. However, sometimes you want to go to another result.

It would be great to have the search box keep the previously-typed query so that the results are already preloaded for rapid navigation.

This change does exactly that.