### PR TITLE
Use CSS line-clamping for text limiting

### DIFF
--- a/src/components/Areas.css
+++ b/src/components/Areas.css
@@ -1,0 +1,6 @@
+.area-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/src/components/Areas.tsx
+++ b/src/components/Areas.tsx
@@ -10,6 +10,7 @@ import { Remarkable } from "remarkable";
 import { linkify } from "remarkable/linkify";
 import { useMeta } from "./common/meta";
 import { HeaderButtons } from "./common/HeaderButtons";
+import "./Areas.css";
 
 const Areas = () => {
   const { data } = useAreas();
@@ -74,12 +75,9 @@ const Areas = () => {
             )}
             {a.comment && (
               <div
+                className="area-description"
                 dangerouslySetInnerHTML={{
-                  __html: md.render(
-                    a.comment && a.comment.length > 200
-                      ? a.comment.substring(0, 200) + "..."
-                      : a.comment,
-                  ),
+                  __html: md.render(a.comment),
                 }}
               />
             )}
@@ -186,11 +184,9 @@ const Areas = () => {
                     <i>{`${area.numSectors} sectors, ${area.numProblems} ${typeDescription}, ${area.hits} page views`}</i>
                     <br />
                     <div
+                      className="area-description"
                       dangerouslySetInnerHTML={{
-                        __html:
-                          area.comment && area.comment.length > 350
-                            ? area.comment.substring(0, 350) + "..."
-                            : area.comment,
+                        __html: area.comment,
                       }}
                     />
                   </List.Description>


### PR DESCRIPTION
The current codebase caps the amount of text shown for area descriptions by chopping to an arbitrary number of characters.

Instead, we can use CSS line clamping to cap it to the desired number of lines and ellipsize automatically.

NOTE: `line-clamp` is still a developing standard, but it's supported [nearly everywhere](https://caniuse.com/css-line-clamp).