### PR TITLE
Don't use indexes as keys

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
   },
   plugins: ["@typescript-eslint", "react"],
   rules: {
+    "react/no-array-index-key": "error",
     "react/react-in-jsx-scope": ["off"],
     "react/prop-types": ["warn"], // Until we get to zero
     "@typescript-eslint/no-explicit-any": ["warn"],

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -28,8 +28,8 @@ const About = () => {
         </Header>
         <List>
           {data ? (
-            data.map((u, key) => (
-              <List.Item key={key}>
+            data.map((u) => (
+              <List.Item key={u.userId}>
                 <Image src={u.picture ? u.picture : "/png/image.png"} />
                 <List.Content>
                   <List.Header as={Link} to={`/user/${u.userId}`}>
@@ -41,7 +41,8 @@ const About = () => {
             ))
           ) : (
             <Placeholder>
-              {[...Array(10)].map((e, i) => (
+              {[...Array(10)].map((_, i) => (
+                // eslint-disable-next-line react/no-array-index-key
                 <Placeholder.Header image key={i}>
                   <Placeholder.Line length="medium" />
                   <Placeholder.Line length="short" />

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -276,8 +276,8 @@ const Area = () => {
       render: () => (
         <Tab.Pane>
           <Item.Group link unstackable>
-            {data[0].sectors.map((sector, i) => (
-              <Item as={Link} to={`/sector/${sector.id}`} key={i}>
+            {data[0].sectors.map((sector) => (
+              <Item as={Link} to={`/sector/${sector.id}`} key={sector.id}>
                 <Image
                   size="small"
                   style={{ maxHeight: "150px", objectFit: "cover" }}
@@ -305,8 +305,8 @@ const Area = () => {
                     />
                   </Item.Header>
                   <Item.Meta>
-                    {sector.typeNumTicked.map((x, i) => (
-                      <p key={i}>
+                    {sector.typeNumTicked.map((x) => (
+                      <p key={`${x.type}/${x.num}/${x.ticked}`}>
                         {x.type + ": " + x.num}
                         {x.ticked > 0 && " (" + x.ticked + " ticked)"}
                       </p>
@@ -452,8 +452,8 @@ const Area = () => {
             <Table.Cell width={3}>Sectors:</Table.Cell>
             <Table.Cell>{data[0].sectors.length}</Table.Cell>
           </Table.Row>
-          {data[0].typeNumTicked.map((t, i) => (
-            <Table.Row key={i}>
+          {data[0].typeNumTicked.map((t) => (
+            <Table.Row key={[t.num, t.ticked].join("/")}>
               <Table.Cell>{t.type + ":"}</Table.Cell>
               <Table.Cell>
                 {t.num}

--- a/src/components/Areas.tsx
+++ b/src/components/Areas.tsx
@@ -142,11 +142,10 @@ const Areas = () => {
         </HeaderButtons>
         <List celled link horizontal size="small">
           {data
-            .filter((a) => a.forDevelopers === showForDevelopers)
-            .map((area, i) => (
-              <React.Fragment key={i}>
+            .filter((area) => area.forDevelopers === showForDevelopers)
+            .map((area) => (
+              <React.Fragment key={area.id}>
                 <List.Item
-                  key={i}
                   as="a"
                   onClick={() => {
                     if (area.lat && area.lng) {
@@ -169,9 +168,9 @@ const Areas = () => {
         {map}
         <List divided relaxed>
           {data
-            .filter((a) => a.forDevelopers === showForDevelopers)
-            .map((area, i) => (
-              <List.Item key={i}>
+            .filter((area) => area.forDevelopers === showForDevelopers)
+            .map((area) => (
+              <List.Item key={area.id}>
                 <List.Content as={Link} to={`/area/${area.id}`}>
                   <List.Header>
                     {area.name}{" "}

--- a/src/components/Frontpage.tsx
+++ b/src/components/Frontpage.tsx
@@ -119,8 +119,13 @@ const Frontpage = () => {
                     <Card.Content extra>
                       <Label.Group size="mini">
                         {frontpage.randomMedia.tagged &&
-                          frontpage.randomMedia.tagged.map((x, i) => (
-                            <Label basic key={i} as={Link} to={`/user/${x.id}`}>
+                          frontpage.randomMedia.tagged.map((x) => (
+                            <Label
+                              basic
+                              key={x.id}
+                              as={Link}
+                              to={`/user/${x.id}`}
+                            >
                               <Icon name="user" />
                               {x.name}
                             </Label>
@@ -151,7 +156,8 @@ const Frontpage = () => {
             >
               <Segment>
                 <Placeholder>
-                  {[...Array(6)].map((e, i) => (
+                  {[...Array(6)].map((_, i) => (
+                    // eslint-disable-next-line react/no-array-index-key
                     <Placeholder.Header image key={i}>
                       <Placeholder.Line />
                     </Placeholder.Header>

--- a/src/components/MediaSvgEdit.tsx
+++ b/src/components/MediaSvgEdit.tsx
@@ -310,7 +310,7 @@ const MediaSvgEdit = () => {
         );
       }
       return (
-        <g key={i}>
+        <g key={[p.c[0].x, p.c[0]].join("x")}>
           {anchors}
           <circle
             className={"buldreinfo-svg-pointer"}
@@ -438,7 +438,7 @@ const MediaSvgEdit = () => {
               <Label
                 as="a"
                 image
-                key={index}
+                key={svg.t}
                 color={activeElementIndex === index ? "green" : "grey"}
                 onClick={() => {
                   if (

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -43,10 +43,10 @@ export const Navigation = () => {
                 <Dropdown.Header>{activeSite.group} REGIONS</Dropdown.Header>
                 {sites
                   .filter((s) => s.group === activeSite.group)
-                  .map((s, i) => (
+                  .map((s) => (
                     <Dropdown.Item
                       active={s.active}
-                      key={i}
+                      key={s.name}
                       as={Link}
                       to={s.url}
                     >
@@ -58,9 +58,9 @@ export const Navigation = () => {
                 {sites
                   .map((g) => g.group)
                   .filter((x, i, a) => a.indexOf(x) == i)
-                  .map((g, i) => (
+                  .map((g) => (
                     <Dropdown.Item
-                      key={i}
+                      key={g}
                       as={Link}
                       to={"/sites/" + g.toLowerCase()}
                     >

--- a/src/components/Permissions.tsx
+++ b/src/components/Permissions.tsx
@@ -83,7 +83,7 @@ const Permissions = () => {
         <Segment>No data</Segment>
       ) : (
         <Card.Group doubling stackable itemsPerRow={4}>
-          {filteredData.map((u, key) => {
+          {filteredData.map((u) => {
             let color: any = "white";
             if (u.write == 2) {
               color = "black";
@@ -103,7 +103,7 @@ const Permissions = () => {
               value = 1;
             }
             return (
-              <Card color={color} key={key} raised>
+              <Card color={color} key={u.userId} raised>
                 <Card.Content>
                   <Image
                     floated="right"

--- a/src/components/Problem/Problem.tsx
+++ b/src/components/Problem/Problem.tsx
@@ -433,8 +433,14 @@ export const Problem = () => {
                 )}
                 {data.faAid.users && (
                   <>
-                    {data.faAid.users.map((u, i) => (
-                      <Label key={i} as={Link} to={`/user/${u.id}`} image basic>
+                    {data.faAid.users.map((u) => (
+                      <Label
+                        key={u.id}
+                        as={Link}
+                        to={`/user/${u.id}`}
+                        image
+                        basic
+                      >
                         {u.picture ? (
                           <img src={u.picture} />
                         ) : (
@@ -476,8 +482,14 @@ export const Problem = () => {
               )}
               {data.fa && (
                 <>
-                  {data.fa.map((u, i) => (
-                    <Label key={i} as={Link} to={`/user/${u.id}`} image basic>
+                  {data.fa.map((u) => (
+                    <Label
+                      key={u.id}
+                      as={Link}
+                      to={`/user/${u.id}`}
+                      image
+                      basic
+                    >
                       {u.picture ? (
                         <img src={u.picture} />
                       ) : (
@@ -548,10 +560,10 @@ export const Problem = () => {
             <Table.Row verticalAlign="top">
               <Table.Cell>On TODO-list:</Table.Cell>
               <Table.Cell>
-                {data.todos.map((u, i) => (
+                {data.todos.map((u) => (
                   <Label
                     size="mini"
-                    key={i}
+                    key={u.idUser}
                     as={Link}
                     to={`/user/${u.idUser}`}
                     image
@@ -640,8 +652,8 @@ export const Problem = () => {
               <Table.Cell verticalAlign="top">Pitches:</Table.Cell>
               <Table.Cell>
                 <Feed size="small">
-                  {data.sections.map((s, i) => (
-                    <Feed.Event key={i}>
+                  {data.sections.map((s) => (
+                    <Feed.Event key={s.nr}>
                       <Feed.Label style={{ marginTop: "8px" }}>
                         {s.nr}
                       </Feed.Label>

--- a/src/components/Problem/ProblemComments/ProblemComments.tsx
+++ b/src/components/Problem/ProblemComments/ProblemComments.tsx
@@ -59,7 +59,7 @@ export const ProblemComments = ({
         Comments:
       </Header>
       {data.comments?.length ? (
-        data.comments.map((c, i) => {
+        data.comments.map((c) => {
           let extra: JSX.Element | null = null;
           if (c.danger) {
             extra = <Label color="red">Flagged as dangerous</Label>;
@@ -78,7 +78,7 @@ export const ProblemComments = ({
             );
           }
           return (
-            <Comment key={i}>
+            <Comment key={[c.idUser, c.date].join("@")}>
               <Comment.Avatar src={c.picture ? c.picture : "/png/image.png"} />
               <Comment.Content>
                 {c.editable && (

--- a/src/components/Problem/ProblemTicks/ProblemTicks.tsx
+++ b/src/components/Problem/ProblemTicks/ProblemTicks.tsx
@@ -12,7 +12,7 @@ export const ProblemTicks = ({ ticks }: { ticks: Tick[] }) => {
         Ticks:
       </Header>
       {ticks?.length ? (
-        ticks.map((t, i) => {
+        ticks.map((t) => {
           let dt = t.date;
           let com: React.ReactNode | null = null;
           if (t.repeats?.length > 0) {
@@ -32,8 +32,8 @@ export const ProblemTicks = ({ ticks }: { ticks: Tick[] }) => {
                   </Table.Cell>
                   <Table.Cell verticalAlign="top">{t.comment}</Table.Cell>
                 </Table.Row>
-                {t.repeats.map((r, i) => (
-                  <Table.Row key={i}>
+                {t.repeats.map((r) => (
+                  <Table.Row key={[r.date, r.comment].join("/")}>
                     <Table.Cell
                       verticalAlign="top"
                       singleLine
@@ -51,7 +51,7 @@ export const ProblemTicks = ({ ticks }: { ticks: Tick[] }) => {
           }
           return (
             <Comment
-              key={i}
+              key={[t.idUser, t.date].join("@")}
               style={{ backgroundColor: t.writable ? "#d2f8d2" : "#ffffff" }}
             >
               <Comment.Avatar src={t.picture ? t.picture : "/png/image.png"} />

--- a/src/components/Problem/ProblemsOnRock/ProblemsOnRock.tsx
+++ b/src/components/Problem/ProblemsOnRock/ProblemsOnRock.tsx
@@ -31,9 +31,9 @@ export const ProblemsOnRock = ({
     <Table.Row verticalAlign="top">
       <Table.Cell>Rock «{rock}»:</Table.Cell>
       <Table.Cell>
-        {problemsOnRock.map((p, key) => (
+        {problemsOnRock.map((p) => (
           <Label
-            key={key}
+            key={p.id}
             as={Link}
             to={`/problem/${p.id}`}
             active={problemId === p.id}

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -285,7 +285,7 @@ const Sector = () => {
     uniqueTypes.push("Projects");
   }
   uniqueTypes.sort();
-  const content = uniqueTypes.map((subType, i) => {
+  const content = uniqueTypes.map((subType) => {
     const header = subType ? subType : "Boulders";
     const problemsOfType = data.problems.filter(
       (p) =>
@@ -298,7 +298,7 @@ const Sector = () => {
         ? problemsOfType.length
         : problemsOfType.length + " (" + numTicked + " ticked)";
     return (
-      <Table.Row key={i}>
+      <Table.Row key={[header, txt].join("/")}>
         <TableCell>{header}:</TableCell>
         <TableCell>{txt}</TableCell>
       </Table.Row>
@@ -421,9 +421,9 @@ const Sector = () => {
               <Table.Cell>Sectors:</Table.Cell>
               <Table.Cell>
                 <Label.Group size="tiny">
-                  {data.sectors.map((s, i) => (
+                  {data.sectors.map((s) => (
                     <Label
-                      key={i}
+                      key={s.id}
                       as={Link}
                       to={`/sector/${s.id}`}
                       active={data.id === s.id}

--- a/src/components/SvgEdit.tsx
+++ b/src/components/SvgEdit.tsx
@@ -453,7 +453,7 @@ const SvgEdit = () => {
     }
     const fill = activePoint === i ? "#00FF00" : "#FF0000";
     return (
-      <g key={i}>
+      <g key={[p.x, p.y].join("x")}>
         {anchors}
         <circle
           className={"buldreinfo-svg-pointer"}
@@ -474,13 +474,25 @@ const SvgEdit = () => {
       </g>
     );
   });
-  anchors.map((a, i) => {
+  anchors.map((a) => {
     circles.push(
-      <circle key={i} fill="#E2011A" cx={a.x} cy={a.y} r={0.006 * w} />,
+      <circle
+        key={[a.x, a.y].join("x")}
+        fill="#E2011A"
+        cx={a.x}
+        cy={a.y}
+        r={0.006 * w}
+      />,
     );
   });
-  const myTexts = texts.map((t, i) => (
-    <text key={i} x={t.x} y={t.y} fontSize="5em" fill={"red"}>
+  const myTexts = texts.map((t) => (
+    <text
+      key={[t.x, t.y].join("x")}
+      x={t.x}
+      y={t.y}
+      fontSize="5em"
+      fill={"red"}
+    >
       {t.txt}
     </text>
   ));

--- a/src/components/Ticks.tsx
+++ b/src/components/Ticks.tsx
@@ -49,8 +49,8 @@ const Ticks = () => {
           </>
         ) : (
           <Feed>
-            {data.ticks.map((t, i) => (
-              <Feed.Event key={i} as={Link} to={`/problem/${t.problemId}`}>
+            {data.ticks.map((t) => (
+              <Feed.Event key={t.id} as={Link} to={`/problem/${t.problemId}`}>
                 <Feed.Content>
                   <Feed.Summary>
                     <Feed.Date>{t.date}</Feed.Date> {t.areaName}{" "}

--- a/src/components/common/activity/activity.tsx
+++ b/src/components/common/activity/activity.tsx
@@ -89,9 +89,9 @@ const Activity = ({ idArea, idSector }) => {
           >
             <Dropdown.Menu>
               <Dropdown.Menu scrolling>
-                {meta.grades.map((a, i) => (
+                {meta.grades.map((a) => (
                   <Dropdown.Item
-                    key={i}
+                    key={a.grade}
                     text={a.grade}
                     onClick={() => {
                       const gradeText =
@@ -166,7 +166,8 @@ const Activity = ({ idArea, idSector }) => {
       {!activity && (
         <Segment vertical>
           <Placeholder fluid>
-            {[...Array(15)].map((e, i) => (
+            {[...Array(15)].map((_, i) => (
+              // eslint-disable-next-line react/no-array-index-key
               <Placeholder.Header image key={i}>
                 <Placeholder.Line length="medium" />
                 <Placeholder.Line length="short" />
@@ -178,12 +179,12 @@ const Activity = ({ idArea, idSector }) => {
       {activity && activity.length === 0 && <Segment vertical>No data</Segment>}
       {activity && activity.length != 0 && (
         <Feed>
-          {activity.map((a, i) => {
+          {activity.map((a) => {
             // FA
             if (a.users) {
               const typeDescription = meta.isBouldering ? "problem" : "route";
               return (
-                <Feed.Event key={i}>
+                <Feed.Event key={a.activityIds.join("+")}>
                   <Feed.Label>
                     {a.problemRandomMediaId > 0 && (
                       <img
@@ -218,9 +219,9 @@ const Activity = ({ idArea, idSector }) => {
                     {a.media && (
                       <LazyLoad>
                         <Feed.Extra images>
-                          {a.media.map((m, i) => (
+                          {a.media.map((m) => (
                             <Link
-                              key={i}
+                              key={m.id}
                               to={`/problem/${a.problemId}?idMedia=${m.id}`}
                             >
                               <Image
@@ -238,10 +239,10 @@ const Activity = ({ idArea, idSector }) => {
                     )}
                     {a.users && (
                       <Feed.Meta>
-                        {a.users.map((u, i) => (
+                        {a.users.map((u) => (
                           <Label
                             basic
-                            key={i}
+                            key={u.id}
                             as={Link}
                             to={`/user/${u.id}`}
                             image
@@ -263,7 +264,7 @@ const Activity = ({ idArea, idSector }) => {
             // Guestbook
             else if (a.message) {
               return (
-                <Feed.Event key={i}>
+                <Feed.Event key={a.activityIds.join("+")}>
                   <Feed.Label>
                     {a.picture && <img src={a.picture} />}
                   </Feed.Label>
@@ -300,9 +301,9 @@ const Activity = ({ idArea, idSector }) => {
                     {a.media && (
                       <LazyLoad>
                         <Feed.Extra images>
-                          {a.media.map((m, i) => (
+                          {a.media.map((m) => (
                             <Link
-                              key={i}
+                              key={m.id}
                               to={`/problem/${a.problemId}?idMedia=${m.id}`}
                             >
                               <Image
@@ -349,7 +350,7 @@ const Activity = ({ idArea, idSector }) => {
                 summary = img;
               }
               return (
-                <Feed.Event key={i}>
+                <Feed.Event key={a.activityIds.join("+")}>
                   <Feed.Label>
                     {a.problemRandomMediaId > 0 && (
                       <img
@@ -382,9 +383,9 @@ const Activity = ({ idArea, idSector }) => {
                     </Feed.Summary>
                     <LazyLoad>
                       <Feed.Extra images>
-                        {a.media.map((m, i) => (
+                        {a.media.map((m) => (
                           <Link
-                            key={i}
+                            key={m.id}
                             to={`/problem/${a.problemId}?idMedia=${m.id}`}
                           >
                             <Image
@@ -406,7 +407,7 @@ const Activity = ({ idArea, idSector }) => {
             else {
               const action = a.repeat ? "repeated" : "ticked";
               return (
-                <Feed.Event key={i}>
+                <Feed.Event key={a.activityIds.join("+")}>
                   <Feed.Label>
                     {a.picture && <img src={a.picture} />}
                   </Feed.Label>

--- a/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
+++ b/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
@@ -23,12 +23,12 @@ const ChartGradeDistribution = ({ idArea, idSector, data }) => {
       return d.num;
     }),
   );
-  const cols = gradeDistribution.map((g, i) => {
+  const cols = gradeDistribution.map((g) => {
     const hPrim = (g.prim / maxValue) * 80 + "%";
     const hSec = (g.sec / maxValue) * 80 + "%";
     const col = (
       <td
-        key={i}
+        key={[g.grade, g.prim, g.sec, g.num, g.sec].join("/")}
         style={{ height: "100%", verticalAlign: "bottom", textAlign: "center" }}
       >
         {g.num > 0 && g.num}
@@ -66,7 +66,7 @@ const ChartGradeDistribution = ({ idArea, idSector, data }) => {
       const hasIce = g.rows.filter((x) => x.numIce > 0).length > 0;
       return (
         <Popup
-          key={i}
+          key={[g.grade, g.prim, g.sec, g.num, g.sec].join("/")}
           inverted
           position="bottom center"
           offset={[0, 20]}
@@ -87,8 +87,8 @@ const ChartGradeDistribution = ({ idArea, idSector, data }) => {
                 </Table.Row>
               </Table.Header>
               <Table.Body>
-                {g.rows.map((s, i) => (
-                  <Table.Row key={i}>
+                {g.rows.map((s) => (
+                  <Table.Row key={s.name}>
                     <Table.Cell>{s.name}</Table.Cell>
                     {hasBoulder && <Table.Cell>{s.numBoulder}</Table.Cell>}
                     {hasSport && <Table.Cell>{s.numSport}</Table.Cell>}
@@ -121,8 +121,8 @@ const ChartGradeDistribution = ({ idArea, idSector, data }) => {
       <tbody>
         <tr>{cols}</tr>
         <tr>
-          {gradeDistribution.map((g, i) => (
-            <td style={{ width: "40px", textAlign: "center" }} key={"td" + i}>
+          {gradeDistribution.map((g) => (
+            <td style={{ width: "40px", textAlign: "center" }} key={g.grade}>
               <strong>{g.grade}</strong>
             </td>
           ))}

--- a/src/components/common/chart/chart.tsx
+++ b/src/components/common/chart/chart.tsx
@@ -29,11 +29,11 @@ function Chart({ data }) {
       return d.fa + d.tick;
     }),
   );
-  const rows = grades.map((g, i) => {
+  const rows = grades.map((g) => {
     const faWidth = (g.fa / maxValue) * 100 + "%";
     const tickWidth = (g.tick / maxValue) * 100 + "%";
     return (
-      <tr key={i}>
+      <tr key={[g.grade, g.fa, g.tick].join("/")}>
         <td style={{ padding: 0, textAlign: "center", whiteSpace: "nowrap" }}>
           {g.grade}
         </td>

--- a/src/components/common/image-upload/image-upload.tsx
+++ b/src/components/common/image-upload/image-upload.tsx
@@ -71,7 +71,7 @@ const ImageUpload = ({
           <br />
           <br />
           <Card.Group itemsPerRow={4} stackable>
-            {media.map((m, i) => {
+            {media.map((m) => {
               let min = 0;
               let sec = 0;
               if (
@@ -83,7 +83,7 @@ const ImageUpload = ({
                   (sec = Math.floor((m.embedMilliseconds / 1000) % 60));
               }
               return (
-                <Card key={i}>
+                <Card key={m.file?.preview ?? m.embedThumbnailUrl}>
                   <Image src={m.file ? m.file.preview : m.embedThumbnailUrl} />
                   <Card.Content>
                     {isMultiPitch && (

--- a/src/components/common/leaflet/leaflet.tsx
+++ b/src/components/common/leaflet/leaflet.tsx
@@ -98,8 +98,8 @@ const Leaflet = ({
             <>
               <b>{r}:</b>
               <br />
-              {markersOnRock.map((m, i) => (
-                <React.Fragment key={i}>
+              {markersOnRock.map((m) => (
+                <React.Fragment key={m.url}>
                   <a rel="noreferrer noopener" target="_blank" href={m.url}>
                     {m.label}
                   </a>

--- a/src/components/common/leaflet/markers.tsx
+++ b/src/components/common/leaflet/markers.tsx
@@ -29,13 +29,13 @@ export default function Markers({
   if (!markers) {
     return null;
   }
-  return markers.map((m, i) => {
+  return markers.map((m) => {
     if (m.isParking) {
       return (
         <Marker
           icon={parkingIcon}
           position={[m.lat, m.lng]}
-          key={i}
+          key={["parking", m.lat, m.lng].join("/")}
           eventHandlers={{
             click: () => {
               if (addEventHandlers) {
@@ -57,10 +57,14 @@ export default function Markers({
       );
     } else if (m.isCamera) {
       return (
-        <Marker icon={weatherIcon} position={[m.lat, m.lng]} key={i}>
+        <Marker
+          icon={weatherIcon}
+          position={[m.lat, m.lng]}
+          key={["camera", m.lat, m.lng].join("/")}
+        >
           <Popup closeButton={false}>
             <b>{m.name}</b>
-            {i.lastUpdated && (
+            {m.lastUpdated && (
               <>
                 {" "}
                 (<i>{m.lastUpdated}</i>)
@@ -91,7 +95,7 @@ export default function Markers({
         <Marker
           icon={m.rock ? rockIcon : markerBlueIcon}
           position={[m.lat, m.lng]}
-          key={i}
+          key={["html", m.lat, m.lng].join("/")}
           ref={(ref) => (markerRefs.current[m.id] = ref)}
         >
           <Tooltip
@@ -109,7 +113,7 @@ export default function Markers({
         <Marker
           icon={markerBlueIcon}
           position={[m.lat, m.lng]}
-          key={i}
+          key={["label", m.lat, m.lng].join("/")}
           eventHandlers={{
             click: () => {
               if (addEventHandlers) {
@@ -133,7 +137,7 @@ export default function Markers({
         <Marker
           icon={markerRedIcon}
           position={[m.lat, m.lng]}
-          key={i}
+          key={["red", m.lat, m.lng].join("/")}
           eventHandlers={{
             click: () => {
               if (addEventHandlers) {

--- a/src/components/common/leaflet/polylines.tsx
+++ b/src/components/common/leaflet/polylines.tsx
@@ -5,10 +5,18 @@ export default function Polylines({ opacity, polylines }) {
   if (!polylines) {
     return null;
   }
-  return polylines.map((p, i) => {
+  return polylines.map((p) => {
     if (p.polyline.length === 1) {
       return (
-        <Circle color="lime" key={i} center={p.polyline[0]} radius={0.5} />
+        <Circle
+          color="lime"
+          // It's not great to use JSON.stringify(..) for this, but I don't
+          // know what type we're actually working with here. This is easier
+          // for now and shouldn't cause any major performance issues.
+          key={JSON.stringify(p.polyline[0])}
+          center={p.polyline[0]}
+          radius={0.5}
+        />
       );
     } else {
       let color = "lime";

--- a/src/components/common/media/media.tsx
+++ b/src/components/common/media/media.tsx
@@ -226,7 +226,7 @@ const Media = ({ numPitches, media, optProblemId }: Props) => {
         />
       )}
       <Card.Group itemsPerRow={5} doubling>
-        {media.map((x, i) => {
+        {media.map((x) => {
           let content;
           if (x.svgs || x.mediaSvgs) {
             content = (
@@ -234,7 +234,6 @@ const Media = ({ numPitches, media, optProblemId }: Props) => {
                 close={null}
                 thumb={true}
                 m={x}
-                key={i}
                 style={style}
                 optProblemId={optProblemId}
                 showText={false}
@@ -246,10 +245,11 @@ const Media = ({ numPitches, media, optProblemId }: Props) => {
             content = (
               <Image
                 alt={x.description}
-                key={i}
                 style={style}
                 src={getImageUrl(x.id, x.crc32, 205)}
-                onError={(i) => (i.target.src = "/png/video_placeholder.png")}
+                onError={(img) =>
+                  (img.target.src = "/png/video_placeholder.png")
+                }
                 rounded
               />
             );
@@ -258,7 +258,7 @@ const Media = ({ numPitches, media, optProblemId }: Props) => {
             <Card
               as="a"
               onClick={() => openModal(x)}
-              key={i}
+              key={x.id}
               raised
               style={{
                 backgroundColor: "rgb(245, 245, 245)",

--- a/src/components/common/media/svg.tsx
+++ b/src/components/common/media/svg.tsx
@@ -28,7 +28,7 @@ const Svg = ({
       }
       return b.nr - a.nr;
     });
-    return topoLines.map((svg, key) => {
+    return topoLines.map((svg) => {
       const path: any = parseSVG(svg.path);
       makeAbsolute(path); // Note: mutates the commands in place!
 
@@ -104,6 +104,7 @@ const Svg = ({
       if (y > h - r) y = h - r;
       const anchors = [];
       if (svg.hasAnchor) {
+        const key = [path[ixAnchor].x, path[ixAnchor].y].join("x");
         anchors.push(
           <circle
             key={key + "_1"}
@@ -124,10 +125,11 @@ const Svg = ({
         );
       }
       if (svg.anchors) {
-        JSON.parse(svg.anchors).map((a, i) => {
+        JSON.parse(svg.anchors).map((a) => {
+          const key = [a.x, a.y].join("x");
           anchors.push(
             <circle
-              key={i + "_1"}
+              key={key + "_1"}
               fill={"#000000"}
               cx={a.x}
               cy={a.y}
@@ -136,7 +138,7 @@ const Svg = ({
           );
           anchors.push(
             <circle
-              key={i + "_2"}
+              key={key + "_2"}
               fill={groupColor}
               cx={a.x}
               cy={a.y}
@@ -147,15 +149,21 @@ const Svg = ({
       }
       const texts =
         svg.texts &&
-        JSON.parse(svg.texts).map((t, i) => (
-          <text key={i} x={t.x} y={t.y} fontSize="5em" fill="red">
+        JSON.parse(svg.texts).map((t) => (
+          <text
+            key={[t.x, t.y].join("x")}
+            x={t.x}
+            y={t.y}
+            fontSize="5em"
+            fill="red"
+          >
             {t.txt}
           </text>
         ));
       return (
         <g
           className={gClassName}
-          key={key}
+          key={svg.path}
           style={style}
           onClick={() => {
             if (close) {

--- a/src/components/common/problem-list/accordion-container.tsx
+++ b/src/components/common/problem-list/accordion-container.tsx
@@ -11,7 +11,7 @@ const AccordionContainer = ({ accordionRows }) => {
   return (
     <Accordion fluid styled attached="bottom">
       {accordionRows.map((d, i) => (
-        <span key={i}>
+        <span key={d.label}>
           <Accordion.Title
             active={activeIndex === i}
             index={i}

--- a/src/components/common/problem-section/problem-section.tsx
+++ b/src/components/common/problem-section/problem-section.tsx
@@ -70,8 +70,8 @@ const ProblemSection = ({
       />
       {sections &&
         sections.length > 1 &&
-        sections.map((s, i) => (
-          <Form.Group widths="equal" key={i} inline>
+        sections.map((s) => (
+          <Form.Group widths="equal" key={s.nr} inline>
             <Form.Field>
               <Input
                 size="mini"

--- a/src/components/common/profile/profile-statistics.tsx
+++ b/src/components/common/profile/profile-statistics.tsx
@@ -233,9 +233,14 @@ const ProfileStatistics = ({ userId, canDownload }: ProfileStatisticsProps) => {
         <ProblemList
           isSectorNotUser={false}
           preferOrderByGrade={data.orderByGrade}
-          rows={data.ticks.map((t, key) => {
+          rows={data.ticks.map((t) => {
             return {
-              element: <TickListItem key={key} tick={t} />,
+              element: (
+                <TickListItem
+                  key={[t.areaName, t.sectorName, t.name].join("/")}
+                  tick={t}
+                />
+              ),
               areaName: t.areaName,
               sectorName: t.sectorName,
               name: t.name,

--- a/src/components/common/tick-modal/tick-modal.tsx
+++ b/src/components/common/tick-modal/tick-modal.tsx
@@ -179,8 +179,8 @@ const TickModal = ({
                   Repeats (enabled on ice climbing and multi pitches for logging
                   additional ascents)
                 </label>
-                {repeats?.map((r, i) => (
-                  <Form.Group key={i} inline unstackable>
+                {repeats?.map((r) => (
+                  <Form.Group key={r.date ?? "undated"} inline unstackable>
                     <Form.Field width={5}>
                       <DatePicker
                         placeholderText="Click to select a date"

--- a/src/components/common/todo/todo.tsx
+++ b/src/components/common/todo/todo.tsx
@@ -28,8 +28,8 @@ const Todo = ({ idArea, idSector }: { idArea: number; idSector: number }) => {
       </Header>
       <List>
         <List.Item>
-          {data.sectors.map((sector, i) => (
-            <List.List key={i}>
+          {data.sectors.map((sector) => (
+            <List.List key={sector.id}>
               {idArea > 0 && (
                 <List.Header>
                   <Link to={`/sector/${sector.id}`}>{sector.name}</Link>
@@ -40,8 +40,8 @@ const Todo = ({ idArea, idSector }: { idArea: number; idSector: number }) => {
                 </List.Header>
               )}
               <List.List>
-                {sector.problems.map((problem, i) => (
-                  <List.Item key={i}>
+                {sector.problems.map((problem) => (
+                  <List.Item key={problem.id}>
                     <List.Header>
                       {`#${problem.nr} `}
                       <Link to={`/problem/${problem.id}`}>
@@ -52,7 +52,7 @@ const Todo = ({ idArea, idSector }: { idArea: number; idSector: number }) => {
                         <small>
                           <i style={{ color: "gray" }}>
                             {problem.partners.map((u, i) => (
-                              <React.Fragment key={i}>
+                              <React.Fragment key={u.id}>
                                 {i === 0 ? " User(s): " : ", "}
                                 <Link to={`/user/${u.id}/todo`}>{u.name}</Link>
                               </React.Fragment>

--- a/src/components/common/top/top.tsx
+++ b/src/components/common/top/top.tsx
@@ -16,8 +16,8 @@ const Top = ({ idArea, idSector }: TopProps) => {
     return <Loading />;
   }
 
-  const rows = top.map((t, i) => (
-    <Table.Row key={i}>
+  const rows = top.map((t) => (
+    <Table.Row key={t.userId}>
       <Table.Cell>#{t.rank}</Table.Cell>
       <Table.Cell>
         <Header as="h4" image>

--- a/src/utils/svg-utils.tsx
+++ b/src/utils/svg-utils.tsx
@@ -325,10 +325,10 @@ export function parseReadOnlySvgs(readOnlySvgs, w, h, minWindowScale) {
           h,
         ),
       );
-      svg.anchors.map((a, i) => {
+      svg.anchors.map((a) => {
         shapes.push(
           <circle
-            key={i}
+            key={`${a.x}x${a.y}`}
             className="buldreinfo-svg-edit-opacity"
             fill="#000000"
             cx={a.x}


### PR DESCRIPTION
When generating a list of things, each item needs a key to give React a handle for internal bookkeeping. This should be based on the item being rendered so that if the data changes (fetching, reordering, editing, etc) then React can correctly identify which item(s) need to be rerendered.

Prior to this change, it was relatively common to use the index of the item in its respective list as the key. This seems to work, but if a new item is inserted, React won't know that `0` !== `0` anymore, and things will get out of sync.

This PR makes it an error to use the index as part of the key generation, and does a pass through the codebase to attempt to generate a useful key for each item. This is a best-effort fix and seems to pass the smoke-test. However, I'm sure that there are cases which were missed (due to a lack of typing). This will not cause any major problems for users, and will gradually reveal itself as more and more of the codebase gets typed.