### PR TITLE
Add prop types to the SVG-related components

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -167,12 +167,12 @@ export function useData<TQueryData = any, TData = TQueryData>(
 export function getImageUrl(
   id: number,
   checksum: number,
-  minDimention?: number,
+  minDimension?: number,
 ): string {
   const crc32 = checksum || 0;
-  if (minDimention) {
+  if (minDimension) {
     return getUrl(
-      `/images?id=${id}&crc32=${crc32}&minDimention=${minDimention}`,
+      `/images?id=${id}&crc32=${crc32}&minDimention=${minDimension}`,
     );
   }
   return getUrl(`/images?id=${id}&crc32=${crc32}`);

--- a/src/components/MediaSvgEdit.tsx
+++ b/src/components/MediaSvgEdit.tsx
@@ -334,16 +334,18 @@ const MediaSvgEdit = () => {
     const x = data.mediaSvgs[activeElementIndex].rappelX;
     const y = data.mediaSvgs[activeElementIndex].rappelY;
     const scale = Math.max(data.width, data.height, minWindowScale);
-    activeRappel = Rappel({
-      x,
-      y,
-      scale,
-      bolted: data.mediaSvgs[activeElementIndex].t === TYPE_RAPPEL_BOLTED,
-      thumb: false,
-      backgroundColor: "white",
-      color: "red",
-      key: "ACTIVE_RAPPEL",
-    });
+    activeRappel = (
+      <Rappel
+        key={"ACTIVE_RAPPEL"}
+        backgroundColor={"white"}
+        bolted={data.mediaSvgs[activeElementIndex].t === TYPE_RAPPEL_BOLTED}
+        color={"red"}
+        scale={scale}
+        thumb={false}
+        x={x}
+        y={y}
+      />
+    );
   }
 
   return (

--- a/src/components/common/media/media-modal.tsx
+++ b/src/components/common/media/media-modal.tsx
@@ -435,13 +435,13 @@ const MediaModal = ({
                             <List.Content>
                               <List.Header>
                                 <svg width="100" height="24">
-                                  {Descent({
-                                    path: "M 0 10 C 100 10 0 0 200 20",
-                                    whiteNotBlack: false,
-                                    scale: 1000,
-                                    thumb: false,
-                                    key: "descent",
-                                  })}
+                                  <Descent
+                                    path={"M 0 10 C 100 10 0 0 200 20"}
+                                    whiteNotBlack={false}
+                                    scale={1000}
+                                    thumb={false}
+                                    key={"descent"}
+                                  />
                                 </svg>
                               </List.Header>
                               <List.Description>Descent</List.Description>
@@ -451,16 +451,16 @@ const MediaModal = ({
                             <List.Content>
                               <List.Header>
                                 <svg width="20" height="24">
-                                  {Rappel({
-                                    x: 8,
-                                    y: 8,
-                                    bolted: true,
-                                    scale: 1000,
-                                    thumb: false,
-                                    backgroundColor: "black",
-                                    color: "white",
-                                    key: "bolted-rappel",
-                                  })}
+                                  <Rappel
+                                    x={8}
+                                    y={8}
+                                    bolted={true}
+                                    scale={1000}
+                                    thumb={false}
+                                    backgroundColor={"black"}
+                                    color={"white"}
+                                    key={"bolted-rappel"}
+                                  />
                                 </svg>
                               </List.Header>
                               <List.Description>
@@ -472,16 +472,16 @@ const MediaModal = ({
                             <List.Content>
                               <List.Header>
                                 <svg width="20" height="24">
-                                  {Rappel({
-                                    x: 8,
-                                    y: 8,
-                                    bolted: false,
-                                    scale: 1000,
-                                    thumb: false,
-                                    backgroundColor: "black",
-                                    color: "white",
-                                    key: "not-bolted-rappel",
-                                  })}
+                                  <Rappel
+                                    x={8}
+                                    y={8}
+                                    bolted={false}
+                                    scale={1000}
+                                    thumb={false}
+                                    backgroundColor={"black"}
+                                    color={"white"}
+                                    key={"not-bolted-rappel"}
+                                  />
                                 </svg>
                               </List.Header>
                               <List.Description>

--- a/src/components/common/media/media.tsx
+++ b/src/components/common/media/media.tsx
@@ -1,4 +1,9 @@
-import React, { useState, useEffect, ComponentProps } from "react";
+import React, {
+  useState,
+  useEffect,
+  ComponentProps,
+  CSSProperties,
+} from "react";
 import LazyLoad from "react-lazyload";
 import { useLocation } from "react-router-dom";
 import {
@@ -15,7 +20,7 @@ import Svg from "./svg";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Loading } from "../widgets/widgets";
 
-const style = {
+const style: CSSProperties = {
   objectFit: "cover",
   position: "absolute",
   top: 0,

--- a/src/components/common/media/svg.tsx
+++ b/src/components/common/media/svg.tsx
@@ -2,6 +2,35 @@ import { parseSVG, makeAbsolute } from "svg-path-parser";
 import { getImageUrl } from "../../../api";
 import { useNavigate } from "react-router-dom";
 import { Descent, Rappel } from "../../../utils/svg-utils";
+import { CSSProperties } from "react";
+
+type SvgProps = {
+  style?: CSSProperties;
+  close: () => void;
+  m: {
+    id: number;
+    width: number;
+    height: number;
+    svgs: {
+      problemId: number;
+      nr: number;
+      problemName: string;
+      problemGrade: string;
+      problemSubtype: string;
+      isTicked: boolean;
+      isTodo: boolean;
+      isDangerous: boolean;
+    }[];
+    crc32: number;
+    embedUrl: number;
+    mediaSvgs: unknown[];
+  };
+  thumb: boolean;
+  optProblemId: number;
+  showText: boolean;
+  problemIdHovered: number;
+  setPoblemIdHovered: (problemId: number) => void;
+};
 
 const Svg = ({
   style,
@@ -12,7 +41,7 @@ const Svg = ({
   showText,
   problemIdHovered,
   setPoblemIdHovered,
-}) => {
+}: SvgProps) => {
   const { outerWidth, outerHeight } = window;
   const navigate = useNavigate();
   const minWindowScale = Math.min(outerWidth, outerHeight);
@@ -220,37 +249,47 @@ const Svg = ({
   function generateMediaSvgShapes(mediaSvgs) {
     let res = [];
     if (mediaSvgs && mediaSvgs.length > 0) {
-      res = mediaSvgs.map((svg, key) => {
-        if (svg.t === "PATH") {
-          return Descent({
-            path: svg.path,
-            whiteNotBlack: true,
-            scale,
-            thumb,
-            key,
-          });
-        } else if (svg.t === "RAPPEL_BOLTED") {
-          return Rappel({
-            x: svg.rappelX,
-            y: svg.rappelY,
-            bolted: true,
-            scale,
-            thumb,
-            backgroundColor: "black",
-            color: "white",
-            key,
-          });
-        } else if (svg.t === "RAPPEL_NOT_BOLTED") {
-          return Rappel({
-            x: svg.rappelX,
-            y: svg.rappelY,
-            bolted: false,
-            scale,
-            thumb,
-            backgroundColor: "black",
-            color: "white",
-            key,
-          });
+      res = mediaSvgs.map((svg) => {
+        switch (svg.t) {
+          case "PATH": {
+            return (
+              <Descent
+                key={svg.path}
+                path={svg.path}
+                whiteNotBlack={true}
+                scale={scale}
+                thumb={thumb}
+              />
+            );
+          }
+          case "RAPPEL_BOLTED": {
+            return (
+              <Rappel
+                key={[svg.rappelX, svg.rappelY].join("x")}
+                x={svg.rappelX}
+                y={svg.rappelY}
+                bolted={true}
+                scale={scale}
+                thumb={thumb}
+                backgroundColor={"black"}
+                color={"white"}
+              />
+            );
+          }
+          case "RAPPEL_NOT_BOLTED": {
+            return (
+              <Rappel
+                key={[svg.rappelX, svg.rappelY].join("x")}
+                x={svg.rappelX}
+                y={svg.rappelY}
+                bolted={false}
+                scale={scale}
+                thumb={thumb}
+                backgroundColor={"black"}
+                color={"white"}
+              />
+            );
+          }
         }
       });
     }
@@ -302,7 +341,7 @@ const Svg = ({
         width={m.width}
         height={m.height}
         style={style}
-      ></canvas>
+      />
       <svg
         overflow="visible"
         className="buldreinfo-svg"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,7 +71,11 @@ function ErrorFallback({
   );
 }
 
-export const Auth0ProviderWithNavigate = ({ children }) => {
+export const Auth0ProviderWithNavigate = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const navigate = useNavigate();
   const domain = "climbing.eu.auth0.com";
   const clientId = "DNJNVzhxbF7PtaBFh7H6iBSNLh2UJWHt";


### PR DESCRIPTION
The SVG-related components didn't have any types for their props, so they were susceptible to a lot of errors. This change adds typing to their props so that errors can be caught preemptively.