### PR TITLE
Allow scoping filter to areas

### DIFF
--- a/src/components/Problems/Problems.tsx
+++ b/src/components/Problems/Problems.tsx
@@ -179,7 +179,10 @@ export const Problems = ({ filterOpen }: Props) => {
               Edit filter
             </Button>
             <Button.Or />
-            <Button compact onClick={() => dispatch({ action: "reset" })}>
+            <Button
+              compact
+              onClick={() => dispatch({ action: "reset", section: "all" })}
+            >
               <Icon name="trash alternate outline" />
               Clear filter
             </Button>

--- a/src/components/common/FilterForm/FilterForm.tsx
+++ b/src/components/common/FilterForm/FilterForm.tsx
@@ -6,12 +6,14 @@ import {
   Button,
   Icon,
   Divider,
+  Container,
 } from "semantic-ui-react";
 import { GradeSelect } from "./GradeSelect";
 import { getLocales } from "../../../api";
 import { useMeta } from "../meta";
 import { useFilter } from "./context";
 import { HeaderButtons } from "../HeaderButtons";
+import { ResetField } from "../../Problems/reducer";
 
 const CLIMBING_OPTIONS = [
   {
@@ -26,9 +28,43 @@ const CLIMBING_OPTIONS = [
   },
 ] as const;
 
+const GroupHeader = ({
+  title,
+  reset,
+}: {
+  title: string;
+  reset: ResetField;
+}) => {
+  const { dispatch } = useFilter();
+
+  return (
+    <Container
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        margin: 4,
+      }}
+    >
+      <Header as="h3" style={{ flex: 1, margin: 0 }}>
+        {title}
+      </Header>
+      <Button
+        icon="trash alternate outline"
+        onClick={() => dispatch({ action: "reset", section: reset })}
+        size="mini"
+        basic
+        compact
+      />
+    </Container>
+  );
+};
+
 export const FilterForm = () => {
   const meta = useMeta();
   const {
+    unfilteredData,
+    filterAreaIds,
     filterOnlyAdmin,
     filterOnlySuperAdmin,
     filterHideTicked,
@@ -49,7 +85,7 @@ export const FilterForm = () => {
           <Button
             icon
             labelPosition="left"
-            onClick={() => dispatch({ action: "reset" })}
+            onClick={() => dispatch({ action: "reset", section: "all" })}
           >
             <Icon name="trash alternate outline" />
             Clear filter
@@ -66,12 +102,12 @@ export const FilterForm = () => {
       </HeaderButtons>
       <Divider />
       <Form.Field>
-        <Header as="h3">Grades</Header>
+        <GroupHeader title="Grades" reset="grades" />
         <GradeSelect />
       </Form.Field>
       {disciplineOptions.length > 1 && (
         <>
-          <Header as="h3">Types</Header>
+          <GroupHeader title="Types" reset="types" />
           <Form.Group inline>
             {disciplineOptions.map((discipline) => (
               <Form.Field key={discipline.key}>
@@ -93,29 +129,27 @@ export const FilterForm = () => {
       )}
       {!meta.isBouldering && (
         <>
-          <Header as="h3">Pitches</Header>
+          <GroupHeader title="Pitches" reset="pitches" />
           <Form.Group inline>
-            {CLIMBING_OPTIONS.map((option) => {
-              return (
-                <Form.Field key={option.key}>
-                  <Checkbox
-                    label={option.text}
-                    checked={!!filterPitches?.[option.value]}
-                    onChange={(_, { checked }) => {
-                      dispatch?.({
-                        action: "toggle-pitches",
-                        option: option.value,
-                        checked,
-                      });
-                    }}
-                  />
-                </Form.Field>
-              );
-            })}
+            {CLIMBING_OPTIONS.map((option) => (
+              <Form.Field key={option.key}>
+                <Checkbox
+                  label={option.text}
+                  checked={!!filterPitches?.[option.value]}
+                  onChange={(_, { checked }) => {
+                    dispatch?.({
+                      action: "toggle-pitches",
+                      option: option.value,
+                      checked,
+                    });
+                  }}
+                />
+              </Form.Field>
+            ))}
           </Form.Group>
         </>
       )}
-      <Header as="h3">Options</Header>
+      <GroupHeader title="Options" reset="options" />
       <Form.Group inline>
         <Form.Field>
           <Checkbox
@@ -149,6 +183,24 @@ export const FilterForm = () => {
             />
           </Form.Field>
         )}
+      </Form.Group>
+      <GroupHeader title="Areas" reset="areas" />
+      <Form.Group inline style={{ display: "flex", flexWrap: "wrap" }}>
+        {unfilteredData.map((area) => (
+          <Form.Field key={area.id}>
+            <Checkbox
+              label={area.name}
+              checked={!!filterAreaIds[area.id]}
+              onChange={(_, { checked }) =>
+                dispatch({
+                  action: "toggle-area",
+                  areaId: area.id,
+                  enabled: checked,
+                })
+              }
+            />
+          </Form.Field>
+        ))}
       </Form.Group>
     </Form>
   );


### PR DESCRIPTION
A common use case for me is to use the filter feature when I'm already at an area and I want to find something to climb (decision paralysis). When I'm doing this, it's annoying to have so much stuff on my little phone screen - and most if it adds zero value because I'm *already at an area*.

This feature allows the user to scope their filtration to specific areas.

It also allows sections of the form to be reset individually.

![image](https://github.com/jossi87/climbing-web/assets/418560/5c33135c-180e-4ed4-9a72-0f98a8640f15)
