### PR TITLE
fix: Show map for sectors with polygon data

### DIFF
--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -175,7 +175,7 @@ const Sector = () => {
       });
     }
   }
-  if (markers.length > 0) {
+  if (markers.length > 0 || data.polygonCoords) {
     const defaultCenter =
       data.lat && data.lat > 0
         ? { lat: data.lat, lng: data.lng }


### PR DESCRIPTION
Currently, the map only shows for sectors with markers. However, if there's polygon data (but no markers) the map is hidden. This shouldn't be the case.

This change adjusts the logic to show the map if there are markers _or_ polygon information.