### PR TITLE
Encforce typing of useData(..)

### DIFF
--- a/src/@types/buldreinfo/index.d.ts
+++ b/src/@types/buldreinfo/index.d.ts
@@ -1,3 +1,5 @@
+import { operations } from "./swagger";
+
 interface Window {
   // Allow us to put arbitrary objects in window
   [key: string]: any;
@@ -8,6 +10,10 @@ declare namespace JSX {
     center: any;
   }
 }
+
 type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
 };
+
+type Success<T extends keyof operations> =
+  operations[T]["responses"]["200"]["schema"];

--- a/src/api.ts
+++ b/src/api.ts
@@ -15,6 +15,7 @@ import {
 } from "./components/DataReloader";
 import { useLocalStorage } from "./utils/use-local-storage";
 import { definitions, operations } from "./@types/buldreinfo/swagger";
+import { Success } from "./@types/buldreinfo";
 
 export function getLocales() {
   return "nb-NO";
@@ -135,7 +136,7 @@ export function usePostData<TVariables, TData = Response>(
   });
 }
 
-export function useData<TQueryData = any, TData = TQueryData>(
+export function useData<TQueryData = unknown, TData = TQueryData>(
   urlSuffix: string,
   {
     queryKey: customQueryKey,
@@ -336,13 +337,24 @@ export function useActivity({
   ticks: boolean;
   media: boolean;
 }) {
-  return useData(
+  return useData<
+    (Success<"getActivity">[number] & {
+      media: { isMovie?: boolean; id: number; crc32: number }[];
+      users: { id: number; picture: string; name: string }[];
+    })[]
+  >(
     `/activity?idArea=${idArea}&idSector=${idSector}&lowerGrade=${lowerGrade}&fa=${fa}&comments=${comments}&ticks=${ticks}&media=${media}`,
+    {
+      queryKey: [
+        `/activity`,
+        { idArea, idSector, lowerGrade, fa, comments, ticks, media },
+      ],
+    },
   );
 }
 
 export function useAreas() {
-  return useData(`/areas`, {
+  return useData<Success<"getAreas">>(`/areas`, {
     queryKey: [`/areas`],
   });
 }
@@ -362,7 +374,7 @@ export function useArea(
 export function getArea(
   accessToken: string | null,
   id: number,
-): Promise<operations["getAreas"]["responses"]["200"]["schema"]> {
+): Promise<Success<"getAreas">> {
   return makeAuthenticatedRequest(accessToken, `/areas?id=${id}`)
     .then((response) => {
       if (response.status === 500) {
@@ -384,7 +396,7 @@ export function getGradeDistribution(
   accessToken: string | null,
   idArea: number,
   idSector: number,
-): Promise<operations["getGradeDistribution"]["responses"]["200"]["schema"]> {
+): Promise<Success<"getGradeDistribution">> {
   return makeAuthenticatedRequest(
     accessToken,
     `/grade/distribution?idArea=${idArea}&idSector=${idSector}`,
@@ -409,7 +421,7 @@ export function useMediaSvg(idMedia: number) {
 
 export function getPermissions(
   accessToken: string | null,
-): Promise<operations["getPermissions"]["responses"]["200"]["schema"]> {
+): Promise<Success<"getPermissions">> {
   return makeAuthenticatedRequest(accessToken, `/permissions`)
     .then((data) => data.json())
     .catch((error) => {
@@ -420,9 +432,11 @@ export function getPermissions(
 
 export function useProblem(id: number, showHiddenMedia: boolean) {
   const client = useQueryClient();
-  const problem = useData(
+  const problem = useData<Success<"getProblem">>(
     `/problem?id=${id}&showHiddenMedia=${showHiddenMedia}`,
-    { queryKey: [`/problem`, { id, showHiddenMedia }] },
+    {
+      queryKey: [`/problem`, { id, showHiddenMedia }],
+    },
   );
   const { data: profile } = useProfile(-1);
   const toggleTodo = usePostData(`/todo?idProblem=${id}`, {
@@ -649,9 +663,12 @@ export function useProfileMedia({
   userId: number;
   captured: boolean;
 }) {
-  return useData(`/profile/media?id=${userId}&captured=${captured}`, {
-    queryKey: [`/profile/media`, { id: userId, captured }],
-  });
+  return useData<Success<"getProfilemedia">>(
+    `/profile/media?id=${userId}&captured=${captured}`,
+    {
+      queryKey: [`/profile/media`, { id: userId, captured }],
+    },
+  );
 }
 
 export function useProfileStatistics(id: number) {
@@ -664,7 +681,7 @@ export function useProfileStatistics(id: number) {
 }
 
 export function useProfileTodo(id: number) {
-  return useData(`/profile/todo?id=${id}`, {
+  return useData<Success<"getProfileTodo">>(`/profile/todo?id=${id}`, {
     queryKey: [`/profile/todo`, { id }],
   });
 }
@@ -869,7 +886,9 @@ export function useTodo({
   idArea: number;
   idSector: number;
 }) {
-  return useData(`/todo?idArea=${idArea}&idSector=${idSector}`);
+  return useData<Success<"getTodo">>(
+    `/todo?idArea=${idArea}&idSector=${idSector}`,
+  );
 }
 
 export function useTop({
@@ -879,7 +898,9 @@ export function useTop({
   idArea: number;
   idSector: number;
 }) {
-  return useData(`/top?idArea=${idArea}&idSector=${idSector}`);
+  return useData<Success<"getTop">>(
+    `/top?idArea=${idArea}&idSector=${idSector}`,
+  );
 }
 
 export function getUserSearch(

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -12,10 +12,11 @@ import {
 } from "semantic-ui-react";
 import { useMeta } from "./common/meta";
 import { useData } from "../api";
+import { Success } from "../@types/buldreinfo";
 
 const About = () => {
   const meta = useMeta();
-  const { data } = useData(`/administrators`);
+  const { data } = useData<Success<"getAdministrators">>(`/administrators`);
   const administrators = (
     <Grid.Column>
       <Segment>

--- a/src/components/Dangerous.tsx
+++ b/src/components/Dangerous.tsx
@@ -5,10 +5,11 @@ import { Segment, Icon, Header } from "semantic-ui-react";
 import { useMeta } from "./common/meta";
 import { useData } from "../api";
 import TableOfContents from "./common/TableOfContents";
+import { Success } from "../@types/buldreinfo";
 
 const Dangerous = () => {
   const meta = useMeta();
-  const { data } = useData(`/dangerous`);
+  const { data } = useData<Success<"getDangerous">>(`/dangerous`);
 
   if (!data) {
     return <Loading />;
@@ -28,22 +29,20 @@ const Dangerous = () => {
   const areas = data.map((area) => ({
     id: area.id,
     lockedAdmin: area.lockedAdmin,
-    lockedSuperAdmin: area.lockedSuperAdmin,
+    lockedSuperadmin: area.lockedSuperadmin,
     name: area.name,
     sectors: area.sectors.map((sector) => ({
       id: sector.id,
       lockedAdmin: sector.lockedAdmin,
-      lockedSuperAdmin: sector.lockedSuperAdmin,
+      lockedSuperadmin: sector.lockedSuperadmin,
       name: sector.name,
       problems: sector.problems.map((problem) => ({
         id: problem.id,
         lockedAdmin: problem.lockedAdmin,
-        lockedSuperAdmin: problem.lockedSuperAdmin,
+        lockedSuperadmin: problem.lockedSuperadmin,
         name: problem.name,
         nr: problem.nr,
         grade: problem.grade,
-        stars: problem.stars,
-        ticked: problem.ticked,
         text: problem.postTxt,
         subText: "(" + problem.postWhen + " - " + problem.postBy + ")",
       })),

--- a/src/components/Frontpage.tsx
+++ b/src/components/Frontpage.tsx
@@ -13,10 +13,11 @@ import { Link } from "react-router-dom";
 import { useMeta } from "./common/meta";
 import { getImageUrl, numberWithCommas, useData } from "../api";
 import Activity from "./common/activity/activity";
+import { Success } from "../@types/buldreinfo";
 
 const Frontpage = () => {
   const meta = useMeta();
-  const { data: frontpage } = useData(`/frontpage`);
+  const { data: frontpage } = useData<Success<"getFrontpage">>(`/frontpage`);
   const type = meta.isBouldering ? "bouldering problems" : "climbing routes";
   const description = `${frontpage?.numProblems} ${type}, ${frontpage?.numTicks} public ascents, ${frontpage?.numImages} images, ${frontpage?.numMovies} ascents on video.`;
 

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -4,10 +4,11 @@ import { Loading } from "./common/widgets/widgets";
 import { useData } from "../api";
 import { useMeta } from "./common/meta";
 import ChartGradeDistribution from "./common/chart-grade-distribution/chart-grade-distribution";
+import { Success } from "../@types/buldreinfo";
 
 const Graph = () => {
   const meta = useMeta();
-  const { data } = useData(`/graph`);
+  const { data } = useData<Success<"getGraph">>(`/graph`);
 
   if (!data) {
     return <Loading />;

--- a/src/components/Permissions.tsx
+++ b/src/components/Permissions.tsx
@@ -14,6 +14,7 @@ import {
 import { Link } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
 import { definitions } from "../@types/buldreinfo/swagger";
+import { Mutable } from "../@types/buldreinfo";
 
 type PermissionsData = definitions["PermissionUser"];
 

--- a/src/components/Problem/ProblemComments/ProblemComments.tsx
+++ b/src/components/Problem/ProblemComments/ProblemComments.tsx
@@ -20,7 +20,10 @@ export const ProblemComments = ({
   const meta = useMeta();
   const { data } = useProblem(+problemId, showHiddenMedia);
 
-  function flagAsDangerous({ id, message }) {
+  function flagAsDangerous({ id, message }: { id?: number; message?: string }) {
+    if (!id || !message) {
+      return;
+    }
     if (confirm("Are you sure you want to flag this comment?")) {
       postComment(
         accessToken,
@@ -38,7 +41,11 @@ export const ProblemComments = ({
     }
   }
 
-  function deleteComment({ id }) {
+  function deleteComment(id?: number) {
+    if (!id) {
+      return;
+    }
+
     if (confirm("Are you sure you want to delete this comment?")) {
       postComment(accessToken, id, data.id, null, false, false, true, []).catch(
         (error) => {
@@ -84,7 +91,7 @@ export const ProblemComments = ({
                 {c.editable && (
                   <Button.Group size="tiny" basic compact floated="right">
                     <Button onClick={() => onShowCommentModal(c)} icon="edit" />
-                    <Button onClick={() => deleteComment(c)} icon="trash" />
+                    <Button onClick={() => deleteComment(c.id)} icon="trash" />
                   </Button.Group>
                 )}
                 <Comment.Author as={Link} to={`/user/${c.idUser}`}>

--- a/src/components/Webcams.tsx
+++ b/src/components/Webcams.tsx
@@ -5,17 +5,19 @@ import { Segment, Header, Icon } from "semantic-ui-react";
 import { Loading } from "./common/widgets/widgets";
 import { useMeta } from "./common/meta";
 import { useData } from "../api";
+import { Success } from "../@types/buldreinfo";
+import { ComponentProps } from "react";
 
 const Webcams = () => {
   const meta = useMeta();
-  const { data } = useData(`/webcams`);
+  const { data } = useData<Success<"getCameras">>(`/webcams`);
   const { json } = useParams();
 
   if (!data) {
     return <Loading />;
   }
 
-  const markers = data
+  const markers: ComponentProps<typeof Leaflet>["markers"] = data
     .filter((c) => c.lat != 0 && c.lng != 0)
     .map((c) => {
       return {

--- a/src/components/common/activity/activity.tsx
+++ b/src/components/common/activity/activity.tsx
@@ -227,8 +227,9 @@ const Activity = ({ idArea, idSector }) => {
                               <Image
                                 style={imgStyle}
                                 src={getImageUrl(m.id, m.crc32, 85)}
-                                onError={(i) =>
-                                  (i.target.src = "/png/video_placeholder.png")
+                                onError={(img) =>
+                                  (img.target.src =
+                                    "/png/video_placeholder.png")
                                 }
                               />
                             </Link>
@@ -237,26 +238,24 @@ const Activity = ({ idArea, idSector }) => {
                         <br />
                       </LazyLoad>
                     )}
-                    {a.users && (
-                      <Feed.Meta>
-                        {a.users.map((u) => (
-                          <Label
-                            basic
-                            key={u.id}
-                            as={Link}
-                            to={`/user/${u.id}`}
-                            image
-                          >
-                            {u.picture ? (
-                              <img src={u.picture} />
-                            ) : (
-                              <Icon name="user" />
-                            )}{" "}
-                            {u.name}
-                          </Label>
-                        ))}
-                      </Feed.Meta>
-                    )}
+                    <Feed.Meta>
+                      {a.users.map((u) => (
+                        <Label
+                          basic
+                          key={u.id}
+                          as={Link}
+                          to={`/user/${u.id}`}
+                          image
+                        >
+                          {u.picture ? (
+                            <img src={u.picture} />
+                          ) : (
+                            <Icon name="user" />
+                          )}{" "}
+                          {u.name}
+                        </Label>
+                      ))}
+                    </Feed.Meta>
                   </Feed.Content>
                 </Feed.Event>
               );
@@ -325,13 +324,21 @@ const Activity = ({ idArea, idSector }) => {
             }
             // Media
             else if (a.media) {
-              const numImg = a.media.filter((m) => !m.isMovie).length;
+              const [numImg, numMov] = a.media.reduce(
+                (acc, { isMovie }) => {
+                  if (isMovie) {
+                    return [acc[0], acc[1] + 1];
+                  } else {
+                    return [acc[0] + 1, acc[1]];
+                  }
+                },
+                [0, 0],
+              );
               const img = numImg > 0 && (
                 <>
                   {numImg} new <Icon name="photo" />
                 </>
               );
-              const numMov = a.media.filter((m) => m.isMovie).length;
               const mov = numMov > 0 && (
                 <>
                   {numMov} new <Icon name="film" />
@@ -341,7 +348,7 @@ const Activity = ({ idArea, idSector }) => {
               if (img && mov) {
                 summary = (
                   <>
-                    {img}and {mov}
+                    {img} and {mov}
                   </>
                 );
               } else if (mov) {
@@ -391,8 +398,8 @@ const Activity = ({ idArea, idSector }) => {
                             <Image
                               style={imgStyle}
                               src={getImageUrl(m.id, m.crc32, 85)}
-                              onError={(i) =>
-                                (i.target.src = "/png/video_placeholder.png")
+                              onError={(img) =>
+                                (img.target.src = "/png/video_placeholder.png")
                               }
                             />
                           </Link>

--- a/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
+++ b/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
@@ -4,7 +4,13 @@ import { Popup, Table } from "semantic-ui-react";
 import { getGradeDistribution, useAccessToken } from "./../../../api";
 import { definitions } from "../../../@types/buldreinfo/swagger";
 
-const ChartGradeDistribution = ({ idArea, idSector, data }) => {
+type Props = {
+  idArea: number;
+  idSector: number;
+  data?: definitions["GradeDistribution"][];
+};
+
+const ChartGradeDistribution = ({ idArea, idSector, data }: Props) => {
   const accessToken = useAccessToken();
   const [gradeDistribution, setGradeDistribution] = useState<
     definitions["GradeDistribution"][]

--- a/src/components/common/tick-modal/tick-modal.tsx
+++ b/src/components/common/tick-modal/tick-modal.tsx
@@ -27,7 +27,7 @@ type TickModalProps = {
   comment: string | null;
   grade: string;
   stars: number | null;
-  repeats: { date: string | null; comment: string }[] | undefined;
+  repeats: { date?: string; comment?: string }[] | undefined;
   date: string | null;
   enableTickRepeats: boolean;
 };


### PR DESCRIPTION
This changes the default type of `useData(..)` from `any` to `unknown`. The implication of this is that typing isn't _required_ to initiate a request, but a type definition is now required to _use_ the result of the request.

This small change should introduce a "pit of success" for future queries by needing their types provided from the get-go.