### PR TITLE
Prefetch the various lazy-loaded chunks

### DIFF
--- a/src/utils/lazyRetry.ts
+++ b/src/utils/lazyRetry.ts
@@ -71,5 +71,17 @@ export const lazy = function (
   componentImport: Parameters<typeof reactLazy>[0],
   componentName: string,
 ) {
+  // Prefetch the chunks when the browser is otherwise idle. Note that this
+  // isn't supported on Safari/Mobile Safari, so we'll just fetch it after a
+  // random interval when the browser is hopefully idle.
+  if (
+    "requestIdleCallback" in window &&
+    typeof window.requestIdleCallback === "function"
+  ) {
+    window.requestIdleCallback(componentImport);
+  } else {
+    window.setTimeout(componentImport, 1000 + Math.random() * 1500);
+  }
+
   return reactLazy(() => lazyRetry(componentImport, componentName));
 };


### PR DESCRIPTION
In order to minimize initial load-time, the site utilizes
code-splitting. This works great, except that it can be a bit annoying
in actual use: if the app is redeployed between when the app was first
loaded and when the user attempts to navigate to a new-to-them section,
they'll need to reload the entire app for it to work. This is not only
visually disruptive, but it's also problematic, as the user won't
always have the best network.

Instead, utilize the `requestIdleCallback(..)` function to initiate a
prefetch when the browser is idle. This will allow the entire app (but
not its data) to be laoded ahead of time.

> **NOTE**: This is [not supported on all browsers][caniuse], so on
> where it isn't supported, we do a little hack and load the chunks
> after a random interval (1s - 2.5s after load).

[caniuse]: https://caniuse.com/requestidlecallback