### PR TITLE
Extract a parsePolyline(..) helper function

### DIFF
--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -35,6 +35,7 @@ import { Remarkable } from "remarkable";
 import { linkify } from "remarkable/linkify";
 import ProblemList from "./common/problem-list/problem-list";
 import { useRedirect } from "../utils/useRedirect";
+import { parsePolyline } from "../utils/polyline";
 
 type Props = {
   sector: any;
@@ -164,22 +165,13 @@ const Area = () => {
   for (const s of data.sectors) {
     let distance: string | null = null;
     if (s.polyline) {
-      const polyline = s.polyline
-        .split(";")
-        .filter((i) => i)
-        .map((e) => e.split(",").map(Number));
+      const polyline = parsePolyline(s.polyline);
       distance = calculateDistance(polyline);
       const label = s.polygonCoords == null && distance;
       polylines.push({ polyline, label });
     }
     if (s.polygonCoords) {
-      const polygon = s.polygonCoords
-        .split(";")
-        .filter((i) => i)
-        .map((c) => {
-          const latLng = c.split(",");
-          return [parseFloat(latLng[0]), parseFloat(latLng[1])];
-        });
+      const polygon = parsePolyline(s.polygonCoords);
       const label = s.name + (distance ? " (" + distance + ")" : "");
       outlines.push({ url: "/sector/" + s.id, label, polygon: polygon });
     }

--- a/src/components/AreaEdit/AreaEdit.tsx
+++ b/src/components/AreaEdit/AreaEdit.tsx
@@ -19,6 +19,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { VisibilitySelectorField } from "../common/VisibilitySelector";
 import { captureException } from "@sentry/react";
 import { useAreaEdit } from "./useAreaEdit";
+import { parsePolyline } from "../../utils/polyline";
 
 export const AreaEdit = () => {
   const meta = useMeta();
@@ -195,16 +196,7 @@ export const AreaEdit = () => {
                 .filter(({ polygonCoords }) => !!polygonCoords)
                 .map(({ polygonCoords }) => ({
                   background: true,
-                  polygon: polygonCoords
-                    .split(";")
-                    .map(
-                      (latlng) =>
-                        latlng.split(",").map((v) => +v) as unknown as [
-                          number,
-                          number,
-                        ],
-                    )
-                    .filter(Boolean),
+                  polygon: parsePolyline(polygonCoords),
                 }))}
               polylines={[]}
               height={"300px"}

--- a/src/components/Problem/Problem.tsx
+++ b/src/components/Problem/Problem.tsx
@@ -34,6 +34,7 @@ import { ProblemsOnRock } from "./ProblemsOnRock";
 import { ProblemTicks } from "./ProblemTicks";
 import { ProblemComments } from "./ProblemComments";
 import { componentDecorator } from "../../utils/componentDecorator";
+import { parsePolyline } from "../../utils/polyline";
 
 export const Problem = () => {
   const accessToken = useAccessToken();
@@ -111,22 +112,11 @@ export const Problem = () => {
     });
   }
   if (markers.length > 0) {
-    const polyline =
-      data.sectorPolyline &&
-      data.sectorPolyline
-        .split(";")
-        .filter((i) => i)
-        .map((e) => e.split(",").map(Number));
+    const polyline = parsePolyline(data.sectorPolyline);
     let outlines;
     let polylines;
     if (data.sectorPolygonCoords && data.lat === 0 && data.lng === 0) {
-      const polygon = data.sectorPolygonCoords
-        .split(";")
-        .filter((i) => i)
-        .map((c) => {
-          const latLng = c.split(",");
-          return [parseFloat(latLng[0]), parseFloat(latLng[1])];
-        });
+      const polygon = parsePolyline(data.sectorPolygonCoords);
       const label =
         data.sectorName +
         (polyline ? " (" + calculateDistance(polyline) + ")" : "");

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -39,6 +39,7 @@ import {
 import Linkify from "react-linkify";
 import { useRedirect } from "../utils/useRedirect";
 import { componentDecorator } from "../utils/componentDecorator";
+import { parsePolyline } from "../utils/polyline";
 
 type Props = {
   problem: any;
@@ -181,25 +182,14 @@ const Sector = () => {
         ? { lat: data.lat, lng: data.lng }
         : meta.defaultCenter;
     const defaultZoom = data.lat && data.lat > 0 ? 15 : meta.defaultZoom;
-    const polyline =
-      data.polyline &&
-      data.polyline
-        .split(";")
-        .filter((i) => i)
-        .map((e) => e.split(",").map(Number));
+    const polyline = parsePolyline(data.polyline);
     let outlines;
     let polylines;
     if (data.polygonCoords && addPolygon) {
-      const polygon = data.polygonCoords
-        .split(";")
-        .filter((i) => i)
-        .map((c) => {
-          const latLng = c.split(",");
-          return [parseFloat(latLng[0]), parseFloat(latLng[1])];
-        });
+      const polygon = parsePolyline(data.polygonCoords);
       const label =
         data.name + (polyline ? " (" + calculateDistance(polyline) + ")" : "");
-      outlines = [{ url: "/sector/" + data.id, label, polygon: polygon }];
+      outlines = [{ url: "/sector/" + data.id, label, polygon }];
     }
     if (polyline) {
       const label = outlines == null ? calculateDistance(polyline) : null;

--- a/src/components/SectorEdit.tsx
+++ b/src/components/SectorEdit.tsx
@@ -26,6 +26,7 @@ import {
 import Leaflet from "./common/leaflet/leaflet";
 import { useNavigate, useParams } from "react-router-dom";
 import { VisibilitySelectorField } from "./common/VisibilitySelector";
+import { parsePolyline } from "../utils/polyline";
 
 const useIds = (): { areaId: number; sectorId: number } => {
   const { sectorId, areaId } = useParams();
@@ -201,13 +202,7 @@ const SectorEdit = () => {
     area.sectors.forEach((sector) => {
       if (sector.id != data.id) {
         if (sector.polygonCoords) {
-          const sectorPolygon = sector.polygonCoords
-            .split(";")
-            .filter((i) => i)
-            .map((c) => {
-              const latLng = c.split(",");
-              return [parseFloat(latLng[0]), parseFloat(latLng[1])];
-            });
+          const sectorPolygon = parsePolyline(sector.polygonCoords);
           outlines.push({
             polygon: sectorPolygon,
             background: true,
@@ -215,46 +210,20 @@ const SectorEdit = () => {
           });
         }
         if (sector.polyline) {
-          const sectorPolyline = sector.polyline
-            .split(";")
-            .filter((i) => i)
-            .map((e) => e.split(",").map(Number));
+          const sectorPolyline = parsePolyline(sector.polyline);
           polylines.push({ polyline: sectorPolyline, background: true });
         }
       }
     });
   }
   let polygonError = false;
-  const polygon =
-    data.polygonCoords &&
-    data.polygonCoords
-      .split(";")
-      .filter((i) => i)
-      .map((c) => {
-        const latLng = c.split(",");
-        if (latLng?.length === 2) {
-          const lat = parseFloat(latLng[0]);
-          const lng = parseFloat(latLng[1]);
-          if (lat > 0 && lng > 0) {
-            return [lat, lng];
-          } else {
-            polygonError = true;
-          }
-        } else {
-          polygonError = true;
-        }
-      })
-      .filter((e) => e?.length === 2 && e[0] > 0 && e[1] > 0);
+  const polygon = parsePolyline(data.polygonCoords, () => {
+    polygonError = true;
+  });
   if (polygon) {
     outlines.push({ polygon, background: false });
   }
-  const polyline =
-    data.polyline &&
-    data.polyline
-      .split(";")
-      .filter((i) => i)
-      .map((e) => e.split(",").map(Number))
-      .filter((e) => e?.length === 2 && e[0] > 0 && e[1] > 0);
+  const polyline = parsePolyline(data.polyline);
   if (polyline) {
     polylines.push({ polyline, background: false });
   }

--- a/src/components/Sites.tsx
+++ b/src/components/Sites.tsx
@@ -5,7 +5,7 @@ import { Segment, Button, Header, Icon } from "semantic-ui-react";
 import Leaflet from "./common/leaflet/leaflet";
 import { Loading } from "./common/widgets/widgets";
 import { useMeta } from "./common/meta";
-import { LatLngTuple } from "leaflet";
+import { parsePolyline } from "../utils/polyline";
 
 const Sites = () => {
   const meta = useMeta();
@@ -16,17 +16,11 @@ const Sites = () => {
   }
   const outlines = meta.sites
     .filter((s) => s.group.toLowerCase() === type)
-    .map((s) => {
-      const polygon: LatLngTuple[] = s.polygonCoords.split(";").map((c) => {
-        const [lat, lng] = c.split(",").map((v) => +v);
-        return [lat, lng] as LatLngTuple;
-      });
-      return {
-        url: s.url,
-        label: s.name,
-        polygon: polygon,
-      };
-    });
+    .map((s) => ({
+      url: s.url,
+      label: s.name,
+      polygon: parsePolyline(s.polygonCoords),
+    }));
   const map = (
     <Leaflet
       autoZoom={true}

--- a/src/components/common/leaflet/distance-math.tsx
+++ b/src/components/common/leaflet/distance-math.tsx
@@ -1,4 +1,6 @@
-export function calculateDistance(polyline) {
+import { LatLngExpression } from "leaflet";
+
+export function calculateDistance(polyline: LatLngExpression[]) {
   let km = 0;
   for (let i = 1; i < polyline.length; i++) {
     const lat1 = polyline[i - 1][0];

--- a/src/utils/polyline.ts
+++ b/src/utils/polyline.ts
@@ -1,0 +1,42 @@
+import { captureMessage } from "@sentry/core";
+import { LatLngExpression } from "leaflet";
+
+export const parsePolyline = (
+  polyline: string,
+  onError?: (msg: string, extra?: Record<string, string>) => void,
+): LatLngExpression[] => {
+  const reportError =
+    onError ??
+    ((message) => {
+      captureMessage("Failed to parse polyline", {
+        extra: { message, polyline },
+      });
+    });
+
+  if (!polyline) {
+    return [];
+  }
+
+  return polyline
+    .split(";")
+    .filter(Boolean)
+    .reduce((acc, value) => {
+      const latlng = value.split(",");
+      if (latlng.length !== 2) {
+        reportError("Wrong number of entries", { value });
+        return acc;
+      }
+      const [lat, lng] = latlng.map((v) => +v);
+      if (Number.isNaN(lat)) {
+        reportError("Invalid latitude", { lat: String(lat), value });
+        return acc;
+      }
+
+      if (Number.isNaN(lng)) {
+        reportError("Invalid longitude", { lng: String(lng), value });
+        return acc;
+      }
+
+      return [...acc, [lat, lng]];
+    }, []);
+};


### PR DESCRIPTION
There is a lot of polyline / polygon coordinate data in the different data models, and this is parsed all over the app. This change pulls out a `parsePolyline(..)` function to avoid copy/pasting this code throughout the app.