### PR TITLE
Correctly zoom when editing an area

### DIFF
--- a/src/components/AreaEdit/AreaEdit.tsx
+++ b/src/components/AreaEdit/AreaEdit.tsx
@@ -42,6 +42,10 @@ export const AreaEdit = () => {
   const save = useCallback<ComponentProps<typeof Form>["onSubmit"]>(
     (event) => {
       event.preventDefault();
+      if (!data.name) {
+        return;
+      }
+
       if (
         !data.trash ||
         confirm("Are you sure you want to move area to trash?")


### PR DESCRIPTION
In the aim of being friendly to developers, `useAreaEdit(..)` would always return an Area-shaped object. However, this caused problems with the map: when setting the initial zoom/center, it wouldn't be later overridden when the real data rolled in.

One way to do this is to recreate the map when the real data is loaded, but that's really flickery and not a great experience.

The better option was to properly return `undefined` until the data has, in fact, been loaded.