### PR TITLE
Finish typing all of the component props

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,8 @@ module.exports = {
   rules: {
     "react/no-array-index-key": "error",
     "react/react-in-jsx-scope": ["off"],
-    "react/prop-types": ["warn"], // Until we get to zero
+    "react/prop-types": ["error"],
+    // Change this to "error" once we get to zero violations.
     "@typescript-eslint/no-explicit-any": ["warn"],
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -36,10 +36,11 @@ import { linkify } from "remarkable/linkify";
 import ProblemList from "./common/problem-list/problem-list";
 import { useRedirect } from "../utils/useRedirect";
 import { parsePolyline } from "../utils/polyline";
+import { definitions } from "../@types/buldreinfo/swagger";
 
 type Props = {
-  sector: any;
-  problem: any;
+  sector: definitions["Area"]["sectors"][number];
+  problem: definitions["Area"]["sectors"][number]["problems"][number];
 };
 
 const SectorListItem = ({ sector, problem }: Props) => {

--- a/src/components/ProblemEdit.tsx
+++ b/src/components/ProblemEdit.tsx
@@ -559,7 +559,6 @@ const ProblemEdit = () => {
               <label>Pitches</label>
               <ProblemSection
                 sections={data.sections}
-                grades={meta.grades}
                 onSectionsUpdated={onSectionsUpdated}
               />
             </Form.Field>

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -40,9 +40,10 @@ import Linkify from "react-linkify";
 import { useRedirect } from "../utils/useRedirect";
 import { componentDecorator } from "../utils/componentDecorator";
 import { parsePolyline } from "../utils/polyline";
+import { definitions } from "../@types/buldreinfo/swagger";
 
 type Props = {
-  problem: any;
+  problem: definitions["Sector"]["problems"][number];
 };
 
 const SectorListItem = ({ problem }: Props) => {

--- a/src/components/common/activity/activity.tsx
+++ b/src/components/common/activity/activity.tsx
@@ -18,7 +18,12 @@ import { LockSymbol, Stars } from "./../../common/widgets/widgets";
 import Linkify from "react-linkify";
 import { componentDecorator } from "../../../utils/componentDecorator";
 
-const Activity = ({ idArea, idSector }) => {
+type Props = {
+  idArea: number;
+  idSector: number;
+};
+
+const Activity = ({ idArea, idSector }: Props) => {
   const [lowerGradeId, setLowerGradeId] = useLocalStorage("lower_grade_id", 0);
   const [lowerGradeText, setLowerGradeText] = useLocalStorage(
     "lower_grade_text",

--- a/src/components/common/chart/chart.tsx
+++ b/src/components/common/chart/chart.tsx
@@ -1,6 +1,11 @@
 import React, { memo } from "react";
+import { definitions } from "../../../@types/buldreinfo/swagger";
 
-function Chart({ data }) {
+type Props = {
+  ticks: NonNullable<definitions["ProfileStatistics"]["ticks"]>;
+};
+
+function Chart({ ticks: data }: Props) {
   const grades = [];
   data.map((t) => {
     const d = grades.filter((val) => {

--- a/src/components/common/media/media-edit-modal.tsx
+++ b/src/components/common/media/media-edit-modal.tsx
@@ -1,7 +1,29 @@
 import React, { useState } from "react";
 import { Button, Modal, Form, Input, Checkbox } from "semantic-ui-react";
+import { definitions } from "../../../@types/buldreinfo/swagger";
 
-const MediaEditModal = ({ save, onCloseWithoutReload, m, numPitches }) => {
+type Media = definitions["Media"];
+
+type Props = {
+  save: (
+    id: NonNullable<Media["id"]>,
+    metadataDescription: NonNullable<
+      NonNullable<Media["mediaMetadata"]>["description"]
+    >,
+    pitch: NonNullable<Media["pitch"]>,
+    trivia: NonNullable<Media["trivia"]>,
+  ) => void;
+  onCloseWithoutReload: () => void;
+  m: Media;
+  numPitches: number;
+};
+
+const MediaEditModal = ({
+  save,
+  onCloseWithoutReload,
+  m,
+  numPitches,
+}: Props) => {
   const [media, setMedia] = useState(m);
   const [saving, setSaving] = useState(false);
 

--- a/src/components/common/problem-list/accordion-container.tsx
+++ b/src/components/common/problem-list/accordion-container.tsx
@@ -1,13 +1,20 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import { Accordion, Icon } from "semantic-ui-react";
 
-const AccordionContainer = ({ accordionRows }) => {
+type Props = {
+  accordionRows: {
+    label: string;
+    length?: number;
+    content: React.ReactNode | string;
+  }[];
+};
+
+const AccordionContainer = ({ accordionRows }: Props) => {
   const [activeIndex, setActiveIndex] = useState(-1);
-  function handleOnClick(e, itemProps) {
-    const { index } = itemProps;
-    const newIndex = activeIndex === index ? -1 : index;
-    setActiveIndex(newIndex);
-  }
+  const handleOnClick = useCallback((_, { index }) => {
+    setActiveIndex((oldValue) => (oldValue === index ? -1 : index));
+  }, []);
+
   return (
     <Accordion fluid styled attached="bottom">
       {accordionRows.map((d, i) => (
@@ -21,7 +28,7 @@ const AccordionContainer = ({ accordionRows }) => {
             {d.label}
           </Accordion.Title>
           <Accordion.Content active={activeIndex === i}>
-            {d.length > 0 ? d.content : <i>No data</i>}
+            {(d.length ?? 0) > 0 ? d.content : <i>No data</i>}
           </Accordion.Content>
         </span>
       ))}

--- a/src/components/common/problem-list/problem-list.tsx
+++ b/src/components/common/problem-list/problem-list.tsx
@@ -5,7 +5,7 @@ import { useLocalStorage } from "../../../utils/use-local-storage";
 import { getLocales } from "../../../api";
 
 interface Row {
-  element: any;
+  element: React.ReactNode;
   areaName: string;
   sectorName: string;
   name: string;
@@ -32,15 +32,13 @@ enum OrderBy {
   rating,
 }
 
-const ProblemList = ({
-  rows,
-  isSectorNotUser,
-  preferOrderByGrade,
-}: {
+type Props = {
   rows: Row[];
   isSectorNotUser: boolean;
   preferOrderByGrade: boolean;
-}) => {
+};
+
+const ProblemList = ({ rows, isSectorNotUser, preferOrderByGrade }: Props) => {
   const [data, setData] = useState(rows);
   const [hideTicked, setHideTicked] = useLocalStorage(
     "problemList-hideTicked",

--- a/src/components/common/problem-section/problem-section.tsx
+++ b/src/components/common/problem-section/problem-section.tsx
@@ -1,11 +1,18 @@
 import React, { useState } from "react";
 import { Form, Input, Dropdown } from "semantic-ui-react";
+import { definitions } from "../../../@types/buldreinfo/swagger";
+import { useMeta } from "../meta";
+
+type Props = {
+  sections: definitions["ProblemSection"][];
+  onSectionsUpdated: (sections: definitions["ProblemSection"][]) => void;
+};
 
 const ProblemSection = ({
   sections: initSections,
-  grades,
   onSectionsUpdated,
-}) => {
+}: Props) => {
+  const { grades } = useMeta();
   const [sections, setSections] = useState(initSections);
 
   function onNumberOfSectionsChange(e, { value }) {
@@ -95,7 +102,7 @@ const ProblemSection = ({
                 selection
                 value={s.grade}
                 onChange={(e, { value }) => {
-                  s.grade = value;
+                  s.grade = String(value);
                   setSections([...sections]);
                   onSectionsUpdated(sections);
                 }}

--- a/src/components/common/profile/profile-statistics.tsx
+++ b/src/components/common/profile/profile-statistics.tsx
@@ -110,7 +110,7 @@ const ProfileStatistics = ({ userId, canDownload }: ProfileStatisticsProps) => {
     (t) => !t.fa && t.idTickRepeat > 0,
   ).length;
   const numFas = data.ticks.filter((t) => t.fa).length;
-  const chart = data.ticks.length > 0 ? <Chart data={data.ticks} /> : null;
+  const chart = data.ticks.length > 0 ? <Chart ticks={data.ticks} /> : null;
   const panes: NonNullable<React.ComponentProps<typeof Tab>["panes"]> = [];
   panes.push({
     menuItem: { key: "stats", icon: "area graph" },

--- a/src/utils/use-leaflet-control.tsx
+++ b/src/utils/use-leaflet-control.tsx
@@ -54,6 +54,7 @@ const createLeafletControl = (useElement) => {
     }, [forceUpdate]);
 
     const contentNode = instance.getContainer();
+    // eslint-disable-next-line react/prop-types
     return contentNode ? createPortal(props.children, contentNode) : null;
   };
   return forwardRef(Component);


### PR DESCRIPTION
Define the last of the React component props. This doesn't make all of the prop definitions **complete** (some of the props are still defined as `any`), but it's a step in the right direction.

This also makes `react/prop-types` an ESLint error to avoid regressing on this.