### PR TITLE
Fix a crash when drawing on a new image

### DIFF
--- a/src/components/MediaSvgEdit.tsx
+++ b/src/components/MediaSvgEdit.tsx
@@ -310,7 +310,7 @@ const MediaSvgEdit = () => {
         );
       }
       return (
-        <g key={[p.c[0].x, p.c[0]].join("x")}>
+        <g key={[p.c?.[0]?.x ?? "x", p.c?.[0].y ?? "y"]?.join("x")}>
           {anchors}
           <circle
             className={"buldreinfo-svg-pointer"}


### PR DESCRIPTION
When drawing the first line on an image, it would crash because the points weren't yet initalized. Handle this gracefully instead of crashing.