### PR TITLE
chore: Centralize redirect behavior

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -16,6 +16,7 @@ import {
 import { useLocalStorage } from "./utils/use-local-storage";
 import { definitions, operations } from "./@types/buldreinfo/swagger";
 import { Success } from "./@types/buldreinfo";
+import { useRedirect } from "./utils/useRedirect";
 
 export function getLocales() {
   return "nb-NO";
@@ -160,7 +161,10 @@ export function useData<TQueryData = unknown, TData = TQueryData>(
     return res.json();
   };
 
-  return useQuery<TQueryData, unknown, TData>(queryKey, queryFn, options);
+  const data = useQuery<TQueryData, unknown, TData>(queryKey, queryFn, options);
+  const redirectUi = useRedirect(data.data);
+  data.isFetched;
+  return { ...data, redirectUi };
 }
 
 export function getImageUrl(

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -34,7 +34,6 @@ import { getImageUrl, getAreaPdfUrl, useAccessToken, useArea } from "../api";
 import { Remarkable } from "remarkable";
 import { linkify } from "remarkable/linkify";
 import ProblemList from "./common/problem-list/problem-list";
-import { useRedirect } from "../utils/useRedirect";
 import { parsePolyline } from "../utils/polyline";
 import { definitions } from "../@types/buldreinfo/swagger";
 
@@ -114,8 +113,7 @@ const Area = () => {
   const accessToken = useAccessToken();
   const meta = useMeta();
   const { areaId } = useParams();
-  const { data, error } = useArea(+areaId);
-  const redirecting = useRedirect(data);
+  const { data, error, redirectUi } = useArea(+areaId);
   const md = new Remarkable({ breaks: true }).use(linkify);
   // open links in new windows
   md.renderer.rules.link_open = (function () {
@@ -129,8 +127,8 @@ const Area = () => {
     };
   })();
 
-  if (redirecting) {
-    return redirecting;
+  if (redirectUi) {
+    return redirectUi;
   }
 
   if (error) {

--- a/src/components/Problem/Problem.tsx
+++ b/src/components/Problem/Problem.tsx
@@ -29,7 +29,6 @@ import {
 import TickModal from "../common/tick-modal/tick-modal";
 import CommentModal from "../common/comment-modal/comment-modal";
 import Linkify from "react-linkify";
-import { useRedirect } from "../../utils/useRedirect";
 import { ProblemsOnRock } from "./ProblemsOnRock";
 import { ProblemTicks } from "./ProblemTicks";
 import { ProblemComments } from "./ProblemComments";
@@ -41,8 +40,10 @@ export const Problem = () => {
   const { problemId } = useParams();
   const [showHiddenMedia, setShowHiddenMedia] = useState(false);
   const meta = useMeta();
-  const { data, error, toggleTodo } = useProblem(+problemId, showHiddenMedia);
-  const redirecting = useRedirect(data);
+  const { data, error, toggleTodo, redirectUi } = useProblem(
+    +problemId,
+    showHiddenMedia,
+  );
 
   const [showTickModal, setShowTickModal] = useState(false);
   const [showCommentModal, setShowCommentModal] = useState<any>(null);
@@ -59,8 +60,8 @@ export const Problem = () => {
     setShowCommentModal(null);
   };
 
-  if (redirecting) {
-    return redirecting;
+  if (redirectUi) {
+    return redirectUi;
   }
 
   if (error) {

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -37,7 +37,6 @@ import {
   useSector,
 } from "../api";
 import Linkify from "react-linkify";
-import { useRedirect } from "../utils/useRedirect";
 import { componentDecorator } from "../utils/componentDecorator";
 import { parsePolyline } from "../utils/polyline";
 import { definitions } from "../@types/buldreinfo/swagger";
@@ -116,11 +115,10 @@ const Sector = () => {
   const accessToken = useAccessToken();
   const { sectorId } = useParams();
   const meta = useMeta();
-  const { data: data, error, isLoading } = useSector(+sectorId);
-  const redirect = useRedirect(data);
+  const { data: data, error, isLoading, redirectUi } = useSector(+sectorId);
 
-  if (redirect) {
-    return redirect;
+  if (redirectUi) {
+    return redirectUi;
   }
 
   if (error) {

--- a/src/utils/useRedirect.tsx
+++ b/src/utils/useRedirect.tsx
@@ -1,15 +1,22 @@
 import React from "react";
 import { Segment } from "semantic-ui-react";
+import { definitions } from "../@types/buldreinfo/swagger";
 
 const Redirecting = () => <Segment>Redirecting &hellip;</Segment>;
 
-export const useRedirect = (
-  data: undefined | Record<string, unknown>,
-): React.ReactNode | null => {
-  if (!data?.redirectUrl || typeof data?.redirectUrl !== "string") {
-    return null;
+const isRedirect = (v: unknown): v is definitions["Redirect"] => {
+  return (
+    !!v &&
+    typeof v === "object" &&
+    typeof (v as definitions["Redirect"]).redirectUrl === "string"
+  );
+};
+
+export const useRedirect = (data: unknown): React.ReactNode | null => {
+  if (isRedirect(data) && data.redirectUrl !== window.location.href) {
+    window.location.href = data.redirectUrl;
+    return <Redirecting />;
   }
 
-  window.location.href = data.redirectUrl;
-  return <Redirecting />;
+  return null;
 };


### PR DESCRIPTION
The current redirect behavior is very endpoint-specific. This is a bit annoying to work with, and susceptible to errors.

Instead, have `useData(..)` check for the redirect logic and see if we should be somewhere else. This adds a `redirectUi` element to the returned object from `useData(..)` which the caller can choose to return if they'd like to (but the client will be redirected regardless).