### PR TITLE
Restore the map on the filter page

### DIFF
--- a/src/components/Areas.tsx
+++ b/src/components/Areas.tsx
@@ -93,13 +93,8 @@ const Areas = () => {
         markers={markers}
         defaultCenter={meta.defaultCenter}
         defaultZoom={meta.defaultZoom}
-        polylines={null}
-        outlines={null}
-        onMouseClick={null}
-        onMouseMove={null}
         showSatelliteImage={false}
         clusterMarkers={!showForDevelopers}
-        rocks={null}
         flyToId={flyToId}
       />
     </div>

--- a/src/components/Dangerous.tsx
+++ b/src/components/Dangerous.tsx
@@ -35,6 +35,7 @@ const Dangerous = () => {
       id: sector.id,
       lockedAdmin: sector.lockedAdmin,
       lockedSuperadmin: sector.lockedSuperadmin,
+      polygonCoords: "",
       name: sector.name,
       problems: sector.problems.map((problem) => ({
         id: problem.id,
@@ -64,7 +65,7 @@ const Dangerous = () => {
             <Header.Subheader>{description}</Header.Subheader>
           </Header.Content>
         </Header>
-        <TableOfContents areas={areas} />
+        <TableOfContents enableMap={false} areas={areas} />
       </Segment>
     </>
   );

--- a/src/components/Problem/Problem.tsx
+++ b/src/components/Problem/Problem.tsx
@@ -139,11 +139,8 @@ export const Problem = () => {
             polylines={polylines}
             defaultCenter={{ lat: markers[0].lat, lng: markers[0].lng }}
             defaultZoom={16}
-            onMouseClick={null}
-            onMouseMove={null}
             showSatelliteImage={true}
             clusterMarkers={false}
-            rocks={null}
             flyToId={null}
           />
         </Tab.Pane>

--- a/src/components/Problems/Problems.tsx
+++ b/src/components/Problems/Problems.tsx
@@ -16,6 +16,7 @@ import TableOfContents from "../common/TableOfContents";
 import { useFilterState } from "./reducer";
 import { FilterContext, FilterForm } from "../common/FilterForm";
 import { HeaderButtons } from "../common/HeaderButtons";
+import { definitions } from "../../@types/buldreinfo/swagger";
 
 type Props = { filterOpen?: boolean };
 
@@ -25,6 +26,42 @@ const description = (
   problems: number,
   kind: "routes" | "problems",
 ): string => `${areas} areas, ${sectors} sectors, ${problems} ${kind}`;
+
+type FilterProblem = {
+  id: number;
+  broken: string;
+  lockedAdmin: boolean;
+  lockedSuperadmin: boolean;
+  name: string;
+  nr: number;
+  grade: string;
+  stars?: number;
+  ticked?: boolean;
+  text: string;
+  subText?: string;
+  lat?: number;
+  lng?: number;
+};
+
+type FilterSector = Pick<definitions["ProblemAreaSector"], "polygonCoords"> & {
+  id: number;
+  lockedAdmin: boolean;
+  lockedSuperadmin: boolean;
+  name: string;
+  lat?: number;
+  lng?: number;
+  problems: FilterProblem[];
+};
+
+type FilterArea = {
+  id: number;
+  lockedAdmin: boolean;
+  lockedSuperadmin: boolean;
+  name: string;
+  lat?: number;
+  lng?: number;
+  sectors: FilterSector[];
+};
 
 export const Problems = ({ filterOpen }: Props) => {
   const { isBouldering, isClimbing } = useMeta();
@@ -64,16 +101,21 @@ export const Problems = ({ filterOpen }: Props) => {
     things,
   );
 
-  const areas = filteredData.map((area) => ({
+  const areas: FilterArea[] = filteredData.map((area) => ({
     id: area.id,
     lockedAdmin: !!area.lockedAdmin,
     lockedSuperadmin: !!area.lockedSuperadmin,
     name: area.name,
+    lat: area.lat,
+    lng: area.lng,
     sectors: area.sectors.map((sector) => ({
       id: sector.id,
       lockedAdmin: !!sector.lockedAdmin,
       lockedSuperadmin: !!sector.lockedSuperadmin,
       name: sector.name,
+      lat: sector.lat,
+      lng: sector.lng,
+      polygonCoords: sector.polygonCoords,
       problems: sector.problems.map((problem) => {
         const ascents =
           problem.numTicks > 0 &&
@@ -102,6 +144,8 @@ export const Problems = ({ filterOpen }: Props) => {
           lockedAdmin: !!problem.lockedAdmin,
           lockedSuperadmin: !!problem.lockedSuperadmin,
           name: problem.name,
+          lat: problem.lat,
+          lng: problem.lng,
           nr: problem.nr,
           grade: problem.grade,
           stars: problem.stars,
@@ -193,7 +237,7 @@ export const Problems = ({ filterOpen }: Props) => {
     </>
   );
 
-  const mainContents = <TableOfContents areas={areas} />;
+  const mainContents = <TableOfContents enableMap areas={areas} />;
 
   const content = visible ? (
     <>

--- a/src/components/Webcams.tsx
+++ b/src/components/Webcams.tsx
@@ -57,16 +57,11 @@ const Webcams = () => {
         <Leaflet
           height="85vh"
           autoZoom={false}
-          outlines={null}
           defaultCenter={defaultCenter}
           defaultZoom={defaultZoom}
           markers={markers}
-          polylines={null}
-          onMouseClick={null}
-          onMouseMove={null}
           showSatelliteImage={false}
           clusterMarkers={false}
-          rocks={null}
           flyToId={null}
         />
       </Segment>

--- a/src/components/common/HeaderButtons/HeaderButtons.tsx
+++ b/src/components/common/HeaderButtons/HeaderButtons.tsx
@@ -3,7 +3,7 @@ import { ButtonGroup, Header, Icon } from "semantic-ui-react";
 
 type Props = {
   icon?: ComponentProps<typeof Icon>["name"];
-  header: string;
+  header?: string;
   subheader?: React.ReactNode;
   children?: React.ReactNode | React.ReactNode[];
 };
@@ -18,17 +18,19 @@ export const HeaderButtons = ({ header, subheader, icon, children }: Props) => {
         alignItems: "flex-end",
       }}
     >
-      <Header as="h2" style={{ marginBottom: 0 }}>
-        {icon && <Icon name={icon} />}
-        <Header.Content>
-          {header}
-          {subheader && (
-            <Header.Subheader style={{ lineWrap: "no-wrap" }}>
-              {subheader}
-            </Header.Subheader>
-          )}
-        </Header.Content>
-      </Header>
+      {header && (
+        <Header as="h2" style={{ marginBottom: 0 }}>
+          {icon && <Icon name={icon} />}
+          <Header.Content>
+            {header}
+            {subheader && (
+              <Header.Subheader style={{ lineWrap: "no-wrap" }}>
+                {subheader}
+              </Header.Subheader>
+            )}
+          </Header.Content>
+        </Header>
+      )}
       <div
         style={{
           display: "flex",

--- a/src/components/common/TableOfContents/ProblemsMap/ProblemsMap.tsx
+++ b/src/components/common/TableOfContents/ProblemsMap/ProblemsMap.tsx
@@ -1,0 +1,170 @@
+import React, { ComponentProps, useEffect, useMemo, useState } from "react";
+import Leaflet from "../../leaflet/leaflet";
+import { useMeta } from "../../meta";
+import { parsePolyline } from "../../../../utils/polyline";
+import Markers, { MarkerDef } from "../../leaflet/markers";
+import type { Props as TocProps } from "../TableOfContents";
+import MarkerClusterGroup from "../../leaflet/react-leaflet-markercluster";
+import { useMap } from "react-leaflet";
+import Polygons from "../../leaflet/polygons";
+import { LatLngBounds, LeafletEventHandlerFn, latLngBounds } from "leaflet";
+
+type Props = Pick<TocProps, "areas">;
+
+const useMapZoom = () => {
+  const map = useMap();
+  const [zoom, setZoom] = useState(0);
+
+  useEffect(() => {
+    const onZoom: LeafletEventHandlerFn = () => {
+      setZoom(map.getZoom());
+    };
+
+    map.addEventListener("zoomend", onZoom);
+    return () => {
+      map.removeEventListener("zoomend", onZoom);
+    };
+  }, [map]);
+
+  return zoom;
+};
+
+const useMarkers = (areas: Props["areas"]): MarkerDef[] => {
+  return useMemo(() => {
+    const markers: MarkerDef[] = [];
+
+    for (const area of areas) {
+      for (const sector of area.sectors) {
+        let sectorBounds: LatLngBounds;
+        for (const problem of sector.problems) {
+          let lat = 0;
+          let lng = 0;
+
+          if (!problem.lat || !problem.lng) {
+            if (sector.polygonCoords) {
+              if (!sectorBounds) {
+                sectorBounds = latLngBounds([]);
+                const parsedBounds = parsePolyline(sector.polygonCoords);
+                for (const latlng of parsedBounds) {
+                  sectorBounds.extend(latlng);
+                }
+              }
+              const { lat: centerLat, lng: centerLng } =
+                sectorBounds.getCenter();
+              lat = centerLat;
+              lng = centerLng;
+            } else if (sector.lat && sector.lng) {
+              lat = sector.lat;
+              lng = sector.lng;
+            }
+          }
+
+          if (!lat || !lng) {
+            continue;
+          }
+
+          markers.push({
+            lat,
+            lng,
+            label: problem.name,
+            url: `/problem/${problem.id}`,
+          });
+        }
+      }
+    }
+
+    return markers;
+  }, [areas]);
+};
+
+const ProblemMarkers = ({ areas }: Props) => {
+  const markers: MarkerDef[] = useMarkers(areas);
+
+  return (
+    <MarkerClusterGroup>
+      <Markers
+        opacity={0.6}
+        markers={markers}
+        addEventHandlers={false}
+        flyToId={null}
+      />
+    </MarkerClusterGroup>
+  );
+};
+
+const ProblemClusters = ({ areas }: Props) => {
+  const zoom = useMapZoom();
+
+  const markers: MarkerDef[] = useMarkers(areas);
+
+  if (zoom > 12) {
+    return null;
+  }
+
+  return (
+    <MarkerClusterGroup>
+      <Markers
+        opacity={0.6}
+        markers={markers}
+        addEventHandlers={false}
+        flyToId={null}
+      />
+    </MarkerClusterGroup>
+  );
+};
+
+const SectorOutlines = ({ areas }: Props) => {
+  const map = useMap();
+  const zoom = useMapZoom();
+
+  const outlines: ComponentProps<typeof Leaflet>["outlines"] = useMemo(() => {
+    const out = [];
+    for (const area of areas) {
+      for (const sector of area.sectors) {
+        if (!sector.polygonCoords) {
+          continue;
+        }
+
+        out.push({
+          polygon: parsePolyline(sector.polygonCoords),
+          url: `/sector/${sector.id}`,
+          label: sector.name,
+        });
+      }
+    }
+    return out;
+  }, [areas]);
+
+  useEffect(() => {
+    const bounds = new LatLngBounds([]);
+    for (const outline of outlines) {
+      for (const latlng of outline.polygon) {
+        bounds.extend(latlng);
+      }
+    }
+    map.flyToBounds(bounds, { duration: 0.5 });
+  }, [map, outlines]);
+
+  return (
+    <Polygons
+      opacity={0.6}
+      outlines={outlines.map(({ label, ...rest }) => ({
+        ...rest,
+        label: zoom > 12 ? label : undefined,
+      }))}
+      addEventHandlers={false}
+    />
+  );
+};
+
+export const ProblemsMap = ({ areas }: Props) => {
+  const { defaultCenter, defaultZoom, isBouldering } = useMeta();
+
+  return (
+    <Leaflet defaultCenter={defaultCenter} defaultZoom={defaultZoom}>
+      <SectorOutlines areas={areas} />
+      {isBouldering && <ProblemMarkers areas={areas} />}
+      {!isBouldering && <ProblemClusters areas={areas} />}
+    </Leaflet>
+  );
+};

--- a/src/components/common/TableOfContents/ProblemsMap/index.ts
+++ b/src/components/common/TableOfContents/ProblemsMap/index.ts
@@ -1,0 +1,1 @@
+export { ProblemsMap } from "./ProblemsMap";

--- a/src/components/common/TableOfContents/TableOfContents.tsx
+++ b/src/components/common/TableOfContents/TableOfContents.tsx
@@ -1,7 +1,10 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { List, Icon } from "semantic-ui-react";
+import { List, Icon, Button } from "semantic-ui-react";
 import { LockSymbol, Stars } from "../../common/widgets/widgets";
+import { definitions } from "../../../@types/buldreinfo/swagger";
+import { ProblemsMap } from "./ProblemsMap";
+import { HeaderButtons } from "../HeaderButtons";
 
 const JumpToTop = () => (
   <a onClick={() => window.scrollTo(0, 0)}>
@@ -9,41 +12,67 @@ const JumpToTop = () => (
   </a>
 );
 
-type Props = {
-  areas: {
-    id: number;
-    lockedAdmin: boolean;
-    lockedSuperadmin: boolean;
-    name: string;
-    sectors: {
-      id: number;
-      lockedAdmin: boolean;
-      lockedSuperadmin: boolean;
-      name: string;
-      problems: {
-        id: number;
-        broken: string;
-        lockedAdmin: boolean;
-        lockedSuperadmin: boolean;
-        name: string;
-        nr: number;
-        grade: string;
-        stars?: number;
-        ticked?: boolean;
-        text?: string;
-        subText?: string;
-      }[];
-    }[];
-  }[];
+export type Props = {
+  enableMap: boolean;
+  areas: (Required<
+    Pick<
+      definitions["Area"],
+      "id" | "lockedAdmin" | "lockedSuperadmin" | "name"
+    >
+  > & {
+    sectors: (Required<
+      Pick<
+        definitions["Sector"],
+        "id" | "name" | "lockedAdmin" | "lockedSuperadmin"
+      >
+    > &
+      Pick<
+        definitions["ProblemAreaSector"],
+        "polygonCoords" | "lat" | "lng"
+      > & {
+        problems: (Required<
+          Pick<
+            definitions["Problem"],
+            "id" | "name" | "lockedAdmin" | "lockedSuperadmin" | "grade" | "nr"
+          >
+        > &
+          Pick<
+            definitions["Problem"],
+            "stars" | "ticked" | "lat" | "lng" | "broken"
+          > & {
+            text?: string;
+            subText?: string;
+          })[];
+      })[];
+  })[];
 };
 
-export const TableOfContents = ({ areas }: Props) => {
+export const TableOfContents = ({ enableMap, areas }: Props) => {
   const areaRefs = useRef({});
+  const [showMap, setShowMap] = useState(
+    enableMap && !!(matchMedia && matchMedia("(pointer:fine)")?.matches),
+  );
+
   if (areas?.length === 0) {
     return <i>No results match your search criteria.</i>;
   }
+
   return (
     <>
+      {enableMap && (
+        <HeaderButtons>
+          <Button
+            toggle={showMap}
+            active={showMap}
+            icon
+            labelPosition="left"
+            onClick={() => setShowMap((v) => !v)}
+          >
+            <Icon name="map outline" />
+            Map
+          </Button>
+        </HeaderButtons>
+      )}
       <List celled link horizontal size="small">
         {areas.map((area) => (
           <React.Fragment key={area.id}>
@@ -62,6 +91,7 @@ export const TableOfContents = ({ areas }: Props) => {
           </React.Fragment>
         ))}
       </List>
+      {showMap && <ProblemsMap areas={areas} />}
       <List celled>
         {areas.map((area) => (
           <List.Item key={area.id}>

--- a/src/components/common/leaflet/markers.tsx
+++ b/src/components/common/leaflet/markers.tsx
@@ -188,7 +188,7 @@ export default function Markers({
         <Marker
           icon={markerBlueIcon}
           position={[m.lat, m.lng]}
-          key={["label", m.lat, m.lng].join("/")}
+          key={["label", m.url].join("/")}
           eventHandlers={{
             click: () => {
               if (addEventHandlers) {

--- a/src/components/common/profile/profile-statistics.tsx
+++ b/src/components/common/profile/profile-statistics.tsx
@@ -212,13 +212,8 @@ const ProfileStatistics = ({ userId, canDownload }: ProfileStatisticsProps) => {
             markers={markers}
             defaultCenter={defaultCenter}
             defaultZoom={defaultZoom}
-            polylines={null}
-            outlines={null}
-            onMouseClick={null}
-            onMouseMove={null}
             showSatelliteImage={false}
             clusterMarkers={true}
-            rocks={null}
             flyToId={null}
           />
         </Tab.Pane>

--- a/src/components/common/profile/profile-todo.tsx
+++ b/src/components/common/profile/profile-todo.tsx
@@ -52,13 +52,8 @@ const ProfileTodo = ({
           markers={markers}
           defaultCenter={defaultCenter}
           defaultZoom={defaultZoom}
-          polylines={null}
-          outlines={null}
-          onMouseClick={null}
-          onMouseMove={null}
           showSatelliteImage={false}
           clusterMarkers={true}
-          rocks={null}
           flyToId={null}
         />
         <List celled>


### PR DESCRIPTION
Make it easier to get a sense of where the different problems and sectors are when filtering the routes/problems by showing a live-updating map on the filter page.

This map will be off by default on mobile devices, as it might be too cluttered and/or battery-intensive and/or network-intensive. However, it can be easily enabled with one button press.