### PR TITLE
fix: Don't adjust the map without bounds

### DIFF
--- a/src/components/common/TableOfContents/ProblemsMap/ProblemsMap.tsx
+++ b/src/components/common/TableOfContents/ProblemsMap/ProblemsMap.tsx
@@ -137,12 +137,16 @@ const SectorOutlines = ({ areas }: Props) => {
 
   useEffect(() => {
     const bounds = new LatLngBounds([]);
+    let boundsExtended = false;
     for (const outline of outlines) {
       for (const latlng of outline.polygon) {
         bounds.extend(latlng);
+        boundsExtended = true;
       }
     }
-    map.flyToBounds(bounds, { duration: 0.5 });
+    if (boundsExtended) {
+      map.flyToBounds(bounds, { duration: 0.5 });
+    }
   }, [map, outlines]);
 
   return (


### PR DESCRIPTION
If the outlines don't have any bounds, don't try to adjust the map, as it will crash. This can happen with outdated cache data (and the crash will prevent fresh data from being loaded).