### PR TITLE
Fix auto-zoom weirdness on the sector edit

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -717,7 +717,7 @@ export function getSectorEdit(
   accessToken: string | null,
   areaId: number,
   sectorId: number,
-): Promise<any> {
+): Promise<Success<"getAreas">[number] | null | Success<"getSectors">> {
   if (!sectorId) {
     return getArea(accessToken, areaId)
       .then((res) => {

--- a/src/components/ProblemEdit.tsx
+++ b/src/components/ProblemEdit.tsx
@@ -579,14 +579,9 @@ const ProblemEdit = () => {
               defaultCenter={defaultCenter}
               defaultZoom={defaultZoom}
               onMouseClick={onMapClick}
-              onMouseMove={null}
-              polylines={null}
-              outlines={null}
               height={"300px"}
               showSatelliteImage={true}
               clusterMarkers={false}
-              rocks={null}
-              flyToId={null}
             />
           </Form.Field>
           <Form.Group widths="equal">

--- a/src/components/common/leaflet/leaflet.tsx
+++ b/src/components/common/leaflet/leaflet.tsx
@@ -86,25 +86,25 @@ const UpdateBounds = ({
   }
 
   const bounds = latLngBounds([]);
-  if (
-    autoZoom &&
-    (!!markers?.length || !!outlines?.length || !!polylines?.length)
-  ) {
-    markers
-      ?.filter(({ lat, lng }) => lat && lng)
-      ?.forEach((m) => bounds.extend([m.lat, m.lng]));
-    outlines
-      ?.filter(({ polygon }) => !!polygon)
-      ?.forEach((o) => o.polygon.forEach((p) => bounds.extend([p[0], p[1]])));
-    polylines
-      ?.filter(({ polyline }) => polyline)
-      ?.forEach((p) => p.polyline.forEach((x) => bounds.extend([x[0], x[1]])));
+  markers
+    ?.filter(({ lat, lng }) => lat && lng)
+    ?.forEach((latlng) => bounds.extend(latlng));
+  outlines
+    ?.filter(({ polygon }) => !!polygon)
+    ?.forEach(({ polygon }) =>
+      polygon.forEach((latlng) => bounds.extend(latlng)),
+    );
+  polylines
+    ?.filter(({ polyline }) => polyline)
+    ?.forEach(({ polyline }) =>
+      polyline.forEach((latlng) => bounds.extend(latlng)),
+    );
 
-    const ne = bounds.getNorthEast();
-    const sw = bounds.getSouthWest();
-    if (ne && sw && ne.lat !== sw.lat && ne.lng !== sw.lng) {
-      map.fitBounds(bounds);
-    }
+  if (
+    bounds.getWest() !== bounds.getEast() &&
+    bounds.getNorth() !== bounds.getSouth()
+  ) {
+    map.fitBounds(bounds);
   }
 
   return null;


### PR DESCRIPTION
When editing map data on the sector page, the map keeps zooming around, which is annoying. Instead, set the zoom once based on the initial data and then leave it as it was.