### PR TITLE
Improve the sector map-editing experience

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -734,7 +734,7 @@ export function getSectorEdit(
   accessToken: string | null,
   areaId: number,
   sectorId: number,
-): Promise<Success<"getAreas">[number] | null | Success<"getSectors">> {
+): Promise<Success<"getSectors"> | null> {
   if (!sectorId) {
     return getArea(accessToken, areaId)
       .then((res) => {
@@ -749,9 +749,8 @@ export function getSectorEdit(
           accessClosed: "",
           lat: 0,
           lng: 0,
-          latStr: "",
-          lngStr: "",
           newMedia: [],
+          problemOrder: [],
         };
       })
       .catch((error) => {

--- a/src/components/SectorEdit/PolylineEditor.tsx
+++ b/src/components/SectorEdit/PolylineEditor.tsx
@@ -1,0 +1,125 @@
+import {
+  Tab,
+  Form,
+  Label,
+  Icon,
+  Input,
+  Button,
+  Message,
+} from "semantic-ui-react";
+import { parsePolyline, colorLatLng } from "../../utils/polyline";
+import GpxParser from "gpxparser";
+import { useCallback } from "react";
+import { DropzoneOptions, useDropzone } from "react-dropzone";
+
+type Props = {
+  polyline: string | undefined;
+  onChange: (polyline: string) => void;
+  upload?: boolean;
+};
+
+export const PolylineEditor = ({ polyline, onChange, upload }: Props) => {
+  const onDrop: DropzoneOptions["onDrop"] = useCallback(
+    (files) => {
+      if (files?.length !== 0) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const gpx = new GpxParser();
+          gpx.parse(e.target?.result as string);
+          const polyline = gpx.tracks[0]?.points
+            ?.map((e) => e.lat + "," + e.lon)
+            .join(";");
+          onChange(polyline);
+        };
+        reader.readAsText(files[0]);
+      }
+    },
+    [onChange],
+  );
+
+  const { getRootProps } = useDropzone({
+    multiple: false,
+    accept: { "application/gpx+xml": [".gpx"] },
+    onDrop,
+  });
+
+  return (
+    <Form.Field>
+      <Tab
+        panes={[
+          {
+            menuItem: "Points",
+            render: () => (
+              <Tab.Pane>
+                {parsePolyline(polyline)?.map((latlng, i) => {
+                  const [backgroundColor, color] = colorLatLng(latlng);
+                  return (
+                    <Label
+                      key={latlng.join(",")}
+                      style={{
+                        backgroundColor,
+                        borderColor: backgroundColor,
+                        color,
+                      }}
+                    >
+                      Point #{i}
+                      <Icon
+                        name="delete"
+                        onClick={() => {
+                          const trimmed = [...parsePolyline(polyline)];
+                          trimmed.splice(i, 1);
+                          onChange(
+                            trimmed.map((latlng) => latlng.join(",")).join(";"),
+                          );
+                        }}
+                      />
+                    </Label>
+                  );
+                })}
+              </Tab.Pane>
+            ),
+          },
+          {
+            menuItem: "Data",
+            render: () => (
+              <Tab.Pane>
+                <Input
+                  placeholder="Outline"
+                  value={polyline || ""}
+                  onChange={(_, { value }) => onChange(value)}
+                  error={false && "Invalid outline"}
+                />
+              </Tab.Pane>
+            ),
+          },
+
+          upload && {
+            menuItem: "GPX",
+            render: () => (
+              <div {...getRootProps()} style={{ textAlign: "center" }}>
+                <Message>
+                  <Message.Content>
+                    Drag-and-drop a <code>.gpx</code> file to create the
+                    approach path. These can be obtained from GPS watches or
+                    from{" "}
+                    <a
+                      href="https://support.strava.com/hc/en-us/articles/216918437-Exporting-your-Data-and-Bulk-Export"
+                      rel="noreferrer noopener"
+                      target="_blank"
+                    >
+                      Strava
+                    </a>
+                    .
+                    <br />
+                    <br />
+                    <Button primary>Upload</Button>
+                  </Message.Content>
+                </Message>
+              </div>
+            ),
+          },
+        ].filter(Boolean)}
+      />
+    </Form.Field>
+  );
+};

--- a/src/components/SectorEdit/PolylineMarkers.tsx
+++ b/src/components/SectorEdit/PolylineMarkers.tsx
@@ -1,0 +1,22 @@
+import { CircleMarker } from "react-leaflet";
+import { parsePolyline, colorLatLng } from "../../utils/polyline";
+
+type Props = {
+  polyline: string | undefined;
+};
+
+export const PolylineMarkers = ({ polyline }: Props) => {
+  if (!polyline) {
+    return null;
+  }
+
+  const parsed = parsePolyline(polyline);
+  return parsed.map((latlng) => (
+    <CircleMarker
+      key={latlng.join(",")}
+      radius={5}
+      center={latlng}
+      color={colorLatLng(latlng)[0]}
+    />
+  ));
+};

--- a/src/components/SectorEdit/ZoomLogic.tsx
+++ b/src/components/SectorEdit/ZoomLogic.tsx
@@ -1,0 +1,50 @@
+import { latLngBounds } from "leaflet";
+import { useRef, useEffect } from "react";
+import { useMap } from "react-leaflet";
+import { definitions } from "../../@types/buldreinfo/swagger";
+import { parsePolyline } from "../../utils/polyline";
+
+type Props = {
+  area: definitions["Area"];
+  sector: definitions["Sector"];
+};
+
+export const ZoomLogic = ({
+  area: loadedArea,
+  sector: loadedSector,
+}: Props) => {
+  const map = useMap();
+  const sectorRef = useRef(loadedSector);
+  const areaRef = useRef(loadedArea);
+
+  useEffect(() => {
+    const bounds = latLngBounds([]);
+    if (sectorRef.current) {
+      if (sectorRef.current.polygonCoords) {
+        for (const latlng of parsePolyline(sectorRef.current.polygonCoords)) {
+          bounds.extend(latlng);
+        }
+      }
+
+      if (sectorRef.current.polyline) {
+        for (const latlng of parsePolyline(sectorRef.current.polyline)) {
+          bounds.extend(latlng);
+        }
+      }
+
+      if (sectorRef.current.lat && sectorRef.current.lng) {
+        bounds.extend([sectorRef.current.lat, sectorRef.current.lng]);
+      }
+    } else if (areaRef.current) {
+      if (areaRef.current.lat && areaRef.current.lng) {
+        bounds.extend([areaRef.current.lat, areaRef.current.lng]);
+      }
+    }
+
+    if (bounds.isValid()) {
+      map.fitBounds(bounds);
+    }
+  }, [map]);
+
+  return null;
+};

--- a/src/components/common/leaflet/markers.tsx
+++ b/src/components/common/leaflet/markers.tsx
@@ -188,7 +188,7 @@ export default function Markers({
         <Marker
           icon={markerBlueIcon}
           position={[m.lat, m.lng]}
-          key={["label", m.url].join("/")}
+          key={["label", m.url, m.lat, m.lng].join("/")}
           eventHandlers={{
             click: () => {
               if (addEventHandlers) {

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,0 +1,49 @@
+const colors = [
+  "red",
+  "orange",
+  "yellow",
+  "olive",
+  "green",
+  "teal",
+  "blue",
+  "violet",
+  "purple",
+  "pink",
+  "brown",
+  "grey",
+  "black",
+] as const;
+
+export const hashSemanticColor = (hash: number): (typeof colors)[number] => {
+  return colors[hash % colors.length];
+};
+
+export const hashHexColor = (hash: number): [`#${string}`, `#${string}`] => {
+  const rgb = `000000${(hash & 0xffffff).toString(16)}`.substr(-6);
+
+  const contrast = contrastingColor(rgb);
+
+  return [`#${rgb}`, `#${contrast}`];
+};
+
+const contrastingColor = (color: string): string => {
+  return luma(color) >= 165 ? "000000" : "ffffff";
+};
+
+const luma = (color: string): number => {
+  const [r, g, b] = hexToRGBArray(color);
+  // SMPTE C, Rec. 709 weightings
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const hexToRGBArray = (color: string): [number, number, number] => {
+  if (color.length !== 6) {
+    throw new Error("Invalid hex color: " + color);
+  }
+
+  return [
+    parseInt(color.substr(0, 2), 16),
+    parseInt(color.substr(2, 2), 16),
+    parseInt(color.substr(4, 2), 16),
+  ];
+};

--- a/src/utils/polyline.ts
+++ b/src/utils/polyline.ts
@@ -1,10 +1,11 @@
 import { captureMessage } from "@sentry/core";
-import { LatLngExpression } from "leaflet";
+import { LatLngTuple } from "leaflet";
+import { hashHexColor } from "./colors";
 
 export const parsePolyline = (
   polyline: string,
   onError?: (msg: string, extra?: Record<string, string>) => void,
-): LatLngExpression[] => {
+): LatLngTuple[] => {
   const reportError =
     onError ??
     ((message) => {
@@ -39,4 +40,32 @@ export const parsePolyline = (
 
       return [...acc, [lat, lng]];
     }, []);
+};
+
+/**
+ * The goal here is to turn a lat,lng pair into a semi-unique number so that it
+ * will have a representative hash code. It's not intended to be perfect, but we
+ * just need "good enough".
+ */
+const hashLatLng = ([lat, lng]: LatLngTuple): number => {
+  const componentSize = Math.floor(String(Number.MAX_SAFE_INTEGER).length / 2);
+  const msbLat = String(lat)
+    .replace(/[^\d]/g, "")
+    .split("")
+    .reverse()
+    .join("")
+    .substring(0, componentSize - 1);
+  const msbLng = String(lng)
+    .replace(/[^\d]/g, "")
+    .split("")
+    .reverse()
+    .join("")
+    .substring(0, componentSize);
+  return Number(`${msbLat}${msbLng}`) % Number.MAX_SAFE_INTEGER;
+};
+
+export const colorLatLng = (
+  latlng: LatLngTuple,
+): ReturnType<typeof hashHexColor> => {
+  return hashHexColor(hashLatLng(latlng));
 };


### PR DESCRIPTION
This change aims to improve the experience of editing the map data for a sector. Specifically:

 1. When drawing an outline, show the user the different points and allow them to delete them individually.
 2. When drawing an approach, do the same thing.
 3. Improve the GPX upload UI a little bit.
 4. Hide the polyline string format by default.
 5. Give the points individual colors so that the user can identify which ones go with which tags.