### PR TITLE
Remove duplicate polyline points

### DIFF
--- a/src/utils/polyline.ts
+++ b/src/utils/polyline.ts
@@ -38,6 +38,11 @@ export const parsePolyline = (
         return acc;
       }
 
+      const last = acc[acc.length - 1];
+      if (lat === last?.[0] && lng === last?.[1]) {
+        return acc;
+      }
+
       return [...acc, [lat, lng]];
     }, []);
 };


### PR DESCRIPTION
When a polyline (approach path, outline) has points back-to-back, it results in a duplicate key. There's no real reason for two identical points to exist back-to-back for these, so this change just drops the redundant ones.