### PR TITLE
Introduce a responsive filter page

### DIFF
--- a/src/components/Dangerous.tsx
+++ b/src/components/Dangerous.tsx
@@ -68,7 +68,7 @@ const Dangerous = () => {
             <Header.Subheader>{description}</Header.Subheader>
           </Header.Content>
         </Header>
-        <TableOfContents enableMap={false} areas={areas} />
+        <TableOfContents areas={areas} />
       </Segment>
     </>
   );

--- a/src/components/Problems/Problems.css
+++ b/src/components/Problems/Problems.css
@@ -1,0 +1,36 @@
+.filter-container {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  grid-template-columns: auto 1fr;
+}
+
+.filter-header {
+  grid-column: 1 / 3;
+}
+
+.filter-form {
+  max-width: 300px;
+}
+
+.filter-form > div {
+  padding: 4px;
+}
+
+@media screen and (max-width: 991px) {
+  .filter-container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .filter-form {
+    max-width: 100%;
+  }
+}
+
+@media screen and (min-height: 800px) {
+  .filter-form > div {
+    position: sticky;
+    top: 0px;
+    overflow-y: auto;
+  }
+}

--- a/src/components/common/FilterForm/FilterForm.tsx
+++ b/src/components/common/FilterForm/FilterForm.tsx
@@ -267,9 +267,10 @@ export const FilterForm = () => {
         <>
           <GroupHeader title="Types" reset="types" />
           <Form.Group inline>
-            {disciplineOptions.map((discipline) => (
-              <Form.Field key={discipline.key}>
+            <Form.Field>
+              {disciplineOptions.map((discipline) => (
                 <Checkbox
+                  key={discipline.key}
                   label={discipline.text}
                   checked={!!filterTypes?.[discipline.value]}
                   onChange={(_, { checked }) => {
@@ -279,9 +280,10 @@ export const FilterForm = () => {
                       checked,
                     });
                   }}
+                  style={{ marginRight: 10 }}
                 />
-              </Form.Field>
-            ))}
+              ))}
+            </Form.Field>
           </Form.Group>
         </>
       )}
@@ -346,9 +348,10 @@ export const FilterForm = () => {
         <>
           <GroupHeader title="Wall direction" reset="wall-directions" />
           <Form.Group inline>
-            {WALL_DIRECTIONS.map((option) => (
-              <Form.Field key={option.key}>
+            <Form.Field>
+              {WALL_DIRECTIONS.map((option) => (
                 <Checkbox
+                  key={option.key}
                   label={option.text}
                   checked={!!filterSectorWallDirections?.[option.value]}
                   onChange={(_, { checked }) => {
@@ -358,9 +361,10 @@ export const FilterForm = () => {
                       checked,
                     });
                   }}
+                  style={{ marginRight: 10 }}
                 />
-              </Form.Field>
-            ))}
+              ))}
+            </Form.Field>
           </Form.Group>
           <GroupHeader title="Conditions" reset="conditions" />
           <Form.Group inline>

--- a/src/components/common/TableOfContents/TableOfContents.tsx
+++ b/src/components/common/TableOfContents/TableOfContents.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import { Link } from "react-router-dom";
-import { List, Icon, Button } from "semantic-ui-react";
+import { List, Icon } from "semantic-ui-react";
 import {
   LockSymbol,
   Stars,
@@ -8,8 +8,6 @@ import {
   WallDirection,
 } from "../../common/widgets/widgets";
 import { components } from "../../../@types/buldreinfo/swagger";
-import { ProblemsMap } from "./ProblemsMap";
-import { HeaderButtons } from "../HeaderButtons";
 
 const JumpToTop = () => (
   <a onClick={() => window.scrollTo(0, 0)}>
@@ -18,7 +16,6 @@ const JumpToTop = () => (
 );
 
 export type Props = {
-  enableMap: boolean;
   areas: (Required<
     Pick<
       components["schemas"]["Area"],
@@ -55,13 +52,12 @@ export type Props = {
           })[];
       })[];
   })[];
+  header?: React.ReactNode;
+  subHeader?: React.ReactNode;
 };
 
-export const TableOfContents = ({ enableMap, areas }: Props) => {
+export const TableOfContents = ({ areas, header, subHeader }: Props) => {
   const areaRefs = useRef({});
-  const [showMap, setShowMap] = useState(
-    enableMap && !!(matchMedia && matchMedia("(pointer:fine)")?.matches),
-  );
 
   if (areas?.length === 0) {
     return <i>No results match your search criteria.</i>;
@@ -69,20 +65,7 @@ export const TableOfContents = ({ enableMap, areas }: Props) => {
 
   return (
     <>
-      {enableMap && (
-        <HeaderButtons>
-          <Button
-            toggle={showMap}
-            active={showMap}
-            icon
-            labelPosition="left"
-            onClick={() => setShowMap((v) => !v)}
-          >
-            <Icon name="map outline" />
-            Map
-          </Button>
-        </HeaderButtons>
-      )}
+      {header}
       <List celled link horizontal size="small">
         {areas.map((area) => (
           <React.Fragment key={area.id}>
@@ -101,7 +84,7 @@ export const TableOfContents = ({ enableMap, areas }: Props) => {
           </React.Fragment>
         ))}
       </List>
-      {showMap && <ProblemsMap areas={areas} />}
+      {subHeader}
       <List celled>
         {areas.map((area) => (
           <List.Item key={area.id}>


### PR DESCRIPTION
The current filter page has a lot of information, and it's presented in the same way on all kinds of devices -- no matter how big the screen is.

This change introduces some CSS-powered responsiveness to the page. On large screens (laptops, desktops, possibly landscape tablets), better-utilize the screen real estate with a two-column layout. On phones, however, keep the stacked layout (and hide the filter by default).

## Screenshots

| Device | Screenshot |
|:---|:---:|
| Desktop | ![image](https://github.com/jossi87/climbing-web/assets/418560/d1002fbc-1232-4123-afce-eee2b67cadbe) |
| iPad Air | ![image](https://github.com/jossi87/climbing-web/assets/418560/bd552248-4208-4787-a6f2-2b4d72d76fd4) |
| iPad mini | ![image](https://github.com/jossi87/climbing-web/assets/418560/362f59b1-18fc-42a7-b73e-1b728e4acc88) |
| Pixel 5 | ![image](https://github.com/jossi87/climbing-web/assets/418560/9a3644ef-6368-4695-b1ad-e563427e2dce) |
