### PR TITLE
Fix: clear areas when clearing the filter

### DIFF
--- a/src/components/Problems/reducer.ts
+++ b/src/components/Problems/reducer.ts
@@ -446,6 +446,7 @@ const reducer = (state: State, update: Update): State => {
         case "all": {
           return {
             ...state,
+            filterAreaIds: {},
             filterGradeLow: undefined,
             filterGradeHigh: undefined,
             filterHideTicked: undefined,


### PR DESCRIPTION
There was as a bug where clicking "Clear filter" would clear everything except the filtered-for areas.

This fixes that.