### PR TITLE
Use fetch from isomorphic-fetch

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -2,6 +2,7 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { useState, useEffect } from "react";
 import { DATA_MUTATION_EVENT } from "../components/DataReloader";
 import { FetchOptions } from "./types";
+import fetch from "isomorphic-fetch";
 
 export function getLocales() {
   return "nb-NO";


### PR DESCRIPTION
When refactoring the `api` module in #123, I overlooked the fact that `fetch` needs to be pulled from `isomorphic-fetch` in order to work.