### PR TITLE
Add typing to API operations

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/@types/buldreinfo/swagger.d.ts

--- a/src/@types/buldreinfo/swagger.d.ts
+++ b/src/@types/buldreinfo/swagger.d.ts
@@ -3,6 +3,7 @@
  * Do not make direct changes to the file.
  */
 
+
 export type paths = {
   "/v2/media": {
     /** Get Media by id */
@@ -1116,9 +1117,7 @@ export type components = {
       providers?: components["schemas"]["Providers"];
       parameterizedHeaders?: {
         empty?: boolean;
-        [key: string]:
-          | components["schemas"]["ParameterizedHeader"][]
-          | undefined;
+        [key: string]: components["schemas"]["ParameterizedHeader"][] | undefined;
       };
     };
     ContentDisposition: {
@@ -1155,9 +1154,7 @@ export type components = {
       simple?: boolean;
       parameterizedHeaders?: {
         empty?: boolean;
-        [key: string]:
-          | components["schemas"]["ParameterizedHeader"][]
-          | undefined;
+        [key: string]: components["schemas"]["ParameterizedHeader"][] | undefined;
       };
     };
     FormDataContentDisposition: {
@@ -1193,9 +1190,7 @@ export type components = {
       };
       parameterizedHeaders?: {
         empty?: boolean;
-        [key: string]:
-          | components["schemas"]["ParameterizedHeader"][]
-          | undefined;
+        [key: string]: components["schemas"]["ParameterizedHeader"][] | undefined;
       };
     };
     MediaType: {
@@ -1222,9 +1217,7 @@ export type components = {
       bodyParts?: components["schemas"]["BodyPart"][];
       parameterizedHeaders?: {
         empty?: boolean;
-        [key: string]:
-          | components["schemas"]["ParameterizedHeader"][]
-          | undefined;
+        [key: string]: components["schemas"]["ParameterizedHeader"][] | undefined;
       };
     };
     MultivaluedMapStringParameterizedHeader: {
@@ -1292,6 +1285,7 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export type operations = {
+
   /** Get Media by id */
   getMedia: {
     parameters: {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,7 +1,7 @@
 export * from "./hooks";
 
 export {
-  getProblemsXlsx,
+  downloadProblemsXlsx,
   deleteMedia,
   moveMedia,
   getElevation,
@@ -9,7 +9,7 @@ export {
   getPermissions,
   getSvgEdit,
   getUserSearch,
-  getUsersTicks,
+  downloadUsersTicks,
   postComment,
   postPermissions,
   postProblem,

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -1,22 +1,15 @@
 import { Success } from "../@types/buldreinfo";
 import { components, operations } from "../@types/buldreinfo/swagger";
-import { makeAuthenticatedRequest } from "./utils";
+import { downloadXlsx, makeAuthenticatedRequest } from "./utils";
 
-export function getProblemsXlsx(accessToken: string | null): Promise<any> {
-  return makeAuthenticatedRequest(accessToken, `/problems/xlsx`, {
-    // @ts-expect-error - I don't think that this is necessary, but I'm going
-    //                    to investigate this later.
-    expose: ["Content-Disposition"],
-  }).catch((error) => {
-    console.warn(error);
-    return null;
-  });
+export function downloadProblemsXlsx(accessToken: string | null) {
+  return downloadXlsx(accessToken, "/problems/xlsx");
 }
 
 export function deleteMedia(
   accessToken: string | null,
   id: number,
-): Promise<any> {
+): Promise<Success<"deleteMedia">> {
   return makeAuthenticatedRequest(accessToken, `/media?id=${id}`, {
     method: "DELETE",
   });
@@ -28,7 +21,7 @@ export function moveMedia(
   left: boolean,
   toIdSector: number,
   toIdProblem: number,
-): Promise<any> {
+): Promise<Success<"putMedia">> {
   return makeAuthenticatedRequest(
     accessToken,
     `/media?id=${id}&left=${left}&toIdSector=${toIdSector}&toIdProblem=${toIdProblem}`,
@@ -179,15 +172,8 @@ export function getUserSearch(
     });
 }
 
-export function getUsersTicks(accessToken: string | null): Promise<any> {
-  return makeAuthenticatedRequest(accessToken, `/users/ticks`, {
-    // @ts-expect-error - I don't think that this is necessary, but I'm going
-    //                    to investigate this later.
-    expose: ["Content-Disposition"],
-  }).catch((error) => {
-    console.warn(error);
-    return null;
-  });
+export function downloadUsersTicks(accessToken: string | null) {
+  return downloadXlsx(accessToken, `/users/ticks`);
 }
 
 export function postComment(
@@ -250,7 +236,7 @@ export function postPermissions(
   adminWrite: boolean,
   superadminRead: boolean,
   superadminWrite: boolean,
-): Promise<any> {
+): Promise<Success<"postPermissions">> {
   return makeAuthenticatedRequest(accessToken, `/permissions`, {
     method: "POST",
     body: JSON.stringify({
@@ -291,7 +277,7 @@ export function postProblem(
   aspect: string,
   routeLength: string,
   descent: string,
-): Promise<any> {
+): Promise<Success<"postProblems">> {
   const formData = new FormData();
   const newMedia = media.map((m) => {
     return {
@@ -357,7 +343,7 @@ export function postProblemMedia(
   accessToken: string | null,
   id: number,
   media: any,
-): Promise<any> {
+): Promise<Success<"postProblemsMedia">> {
   const formData = new FormData();
   const newMedia = media.map((m) => {
     return {
@@ -402,7 +388,7 @@ export function postProblemSvg(
   hasAnchor: boolean,
   anchors: string,
   texts: string,
-): Promise<any> {
+): Promise<Success<"postProblemsSvg">> {
   return makeAuthenticatedRequest(
     accessToken,
     `/problems/svg?problemId=${problemId}&mediaId=${mediaId}`,
@@ -441,7 +427,7 @@ export function postSector(
   approach: components["schemas"]["Approach"],
   media: any,
   problemOrder: any,
-): Promise<any> {
+): Promise<Success<"postSectors">> {
   const formData = new FormData();
   const newMedia = media.map((m) => {
     return {
@@ -504,7 +490,7 @@ export function postTicks(
   stars: number,
   grade: string,
   repeats: any,
-): Promise<any> {
+): Promise<Success<"postTicks">> {
   return makeAuthenticatedRequest(accessToken, `/ticks`, {
     method: "POST",
     body: JSON.stringify({
@@ -527,7 +513,7 @@ export function postUserRegion(
   accessToken: string | null,
   regionId: number,
   del: boolean,
-): Promise<any> {
+): Promise<Success<"postUserRegions">> {
   return makeAuthenticatedRequest(
     accessToken,
     `/user/regions?regionId=${regionId}&delete=${del}`,
@@ -543,7 +529,7 @@ export function putMediaInfo(
   description: string,
   pitch: number,
   trivia: boolean,
-): Promise<any> {
+): Promise<Success<"putMediaInfo">> {
   return makeAuthenticatedRequest(accessToken, `/media/info`, {
     method: "PUT",
     body: JSON.stringify({ mediaId, description, pitch, trivia }),

--- a/src/components/Problems/Problems.tsx
+++ b/src/components/Problems/Problems.tsx
@@ -10,8 +10,7 @@ import {
 } from "semantic-ui-react";
 import { Loading } from "../common/widgets/widgets";
 import { useMeta } from "../common/meta";
-import { getProblemsXlsx, useAccessToken, useProblems } from "../../api";
-import { saveAs } from "file-saver";
+import { downloadProblemsXlsx, useAccessToken, useProblems } from "../../api";
 import TableOfContents from "../common/TableOfContents";
 import { useFilterState } from "./reducer";
 import { FilterContext, FilterForm } from "../common/FilterForm";
@@ -208,18 +207,9 @@ export const Problems = ({ filterOpen }: Props) => {
                 labelPosition="left"
                 onClick={() => {
                   setIsSaving(true);
-                  let filename = "problems.xlsx";
-                  getProblemsXlsx(accessToken)
-                    .then((response) => {
-                      filename = response.headers
-                        .get("content-disposition")
-                        .slice(22, -1);
-                      return response.blob();
-                    })
-                    .then((blob) => {
-                      setIsSaving(false);
-                      saveAs(blob, filename);
-                    });
+                  downloadProblemsXlsx(accessToken).finally(() => {
+                    setIsSaving(false);
+                  });
                 }}
               >
                 <Icon name="file excel" />

--- a/src/components/common/profile/profile-statistics.tsx
+++ b/src/components/common/profile/profile-statistics.tsx
@@ -15,11 +15,10 @@ import {
 } from "semantic-ui-react";
 import {
   numberWithCommas,
-  getUsersTicks,
+  downloadUsersTicks,
   useAccessToken,
   useProfileStatistics,
 } from "../../../api";
-import { saveAs } from "file-saver";
 import { useMeta } from "../meta";
 import * as Sentry from "@sentry/react";
 import { components } from "../../../@types/buldreinfo/swagger";
@@ -131,18 +130,9 @@ const ProfileStatistics = ({ userId, canDownload }: ProfileStatisticsProps) => {
             loading={isSaving}
             onClick={() => {
               setIsSaving(true);
-              let filename = "ticks.xlsx";
-              getUsersTicks(accessToken)
-                .then((response) => {
-                  filename = response.headers
-                    .get("content-disposition")
-                    .slice(22, -1);
-                  return response.blob();
-                })
-                .then((blob) => {
-                  setIsSaving(false);
-                  saveAs(blob, filename);
-                });
+              downloadUsersTicks(accessToken).finally(() => {
+                setIsSaving(false);
+              });
             }}
           />
         )}


### PR DESCRIPTION
Add return typing to the API operations, instead of `any` typing. This also introduces a centralized "download `.xlsx`" functionality since it was spread into the component logic.