### PR TITLE
Spruce up the elevation display

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,7 +4,6 @@ export {
   downloadProblemsXlsx,
   deleteMedia,
   moveMedia,
-  getElevation,
   getGradeDistribution,
   getPermissions,
   getSvgEdit,

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -31,23 +31,6 @@ export function moveMedia(
   );
 }
 
-export function getElevation(
-  accessToken: string | null,
-  latitude: number,
-  longitude: number,
-): Promise<Success<"getElevation">> {
-  return makeAuthenticatedRequest(
-    accessToken,
-    `/elevation?latitude=${latitude}&longitude=${longitude}`,
-    null,
-  )
-    .then((res) => res.text())
-    .catch((error) => {
-      console.warn(error);
-      return null;
-    });
-}
-
 export function getGradeDistribution(
   accessToken: string | null,
   idArea: number,


### PR DESCRIPTION
Do a little revamping of the display of the elevation that's under the current cursor when editing a sector. This is admittedly a bit of overkill, but it at least hides the debounce state logic from the component level and exposes a cleaner API.

By utilizing the `@tanstack/react-query` library, we can expose more information about the underlying data (ie, is it being fetched or not).

And, on the off chance that the user ever requested the _exact same latitude & longitude_, it'd be filled instantly from cache!