### PR TITLE
Migrate getGradeDistribution to react-query

### DIFF
--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -495,3 +495,18 @@ export function useElevation() {
     setLocation: throttledSetLocation,
   };
 }
+
+export function useGradeDistribution(
+  idArea: number,
+  idSector: number,
+  data: components["schemas"]["GradeDistribution"][] | undefined,
+) {
+  return useData<Success<"getGradeDistribution">>(
+    `/grade/distribution?idArea=${idArea}&idSector=${idSector}`,
+    {
+      queryKey: [`/grade/distribution`, { idArea, idSector }],
+      enabled: !!idArea || !!idSector,
+      initialData: data,
+    },
+  );
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,7 +4,6 @@ export {
   downloadProblemsXlsx,
   deleteMedia,
   moveMedia,
-  getGradeDistribution,
   getPermissions,
   getSvgEdit,
   getUserSearch,

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -31,23 +31,6 @@ export function moveMedia(
   );
 }
 
-export function getGradeDistribution(
-  accessToken: string | null,
-  idArea: number,
-  idSector: number,
-): Promise<Success<"getGradeDistribution">> {
-  return makeAuthenticatedRequest(
-    accessToken,
-    `/grade/distribution?idArea=${idArea}&idSector=${idSector}`,
-    null,
-  )
-    .then((data) => data.json())
-    .catch((error) => {
-      console.warn(error);
-      return null;
-    });
-}
-
 export function getPermissions(
   accessToken: string | null,
 ): Promise<Success<"getPermissions">> {

--- a/src/components/Area.tsx
+++ b/src/components/Area.tsx
@@ -247,7 +247,7 @@ const Area = () => {
       menuItem: { key: "distribution", icon: "area graph" },
       render: () => (
         <Tab.Pane>
-          <ChartGradeDistribution idArea={data.id} idSector={0} data={null} />
+          <ChartGradeDistribution idArea={data.id} />
         </Tab.Pane>
       ),
     });

--- a/src/components/Areas.tsx
+++ b/src/components/Areas.tsx
@@ -67,9 +67,7 @@ const Areas = () => {
             </Link>
             <i>{`(${a.numSectors} sectors, ${a.numProblems} ${typeDescription})`}</i>
             <br />
-            {a.numProblems > 0 && (
-              <ChartGradeDistribution idArea={a.id} idSector={0} data={null} />
-            )}
+            {a.numProblems > 0 && <ChartGradeDistribution idArea={a.id} />}
             {a.comment && (
               <div
                 className="area-description"

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -30,7 +30,7 @@ const Graph = () => {
             <Header.Subheader>{description}</Header.Subheader>
           </Header.Content>
         </Header>
-        <ChartGradeDistribution idArea={0} idSector={0} data={data} />
+        <ChartGradeDistribution data={data} />
       </Segment>
     </>
   );

--- a/src/components/Sector.tsx
+++ b/src/components/Sector.tsx
@@ -267,7 +267,7 @@ const Sector = () => {
       menuItem: { key: "distribution", icon: "area graph" },
       render: () => (
         <Tab.Pane>
-          <ChartGradeDistribution idArea={0} idSector={data.id} data={null} />
+          <ChartGradeDistribution idSector={data.id} />
         </Tab.Pane>
       ),
     });

--- a/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
+++ b/src/components/common/chart-grade-distribution/chart-grade-distribution.tsx
@@ -1,32 +1,31 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Loading } from "../widgets/widgets";
 import { Popup, Table } from "semantic-ui-react";
-import { getGradeDistribution, useAccessToken } from "./../../../api";
+import { useGradeDistribution } from "./../../../api";
 import { components } from "../../../@types/buldreinfo/swagger";
 
-type Props = {
-  idArea: number;
-  idSector: number;
-  data?: components["schemas"]["GradeDistribution"][];
-};
+type Data = components["schemas"]["GradeDistribution"][];
 
-const ChartGradeDistribution = ({ idArea, idSector, data }: Props) => {
-  const accessToken = useAccessToken();
-  const [gradeDistribution, setGradeDistribution] = useState<
-    components["schemas"]["GradeDistribution"][]
-  >(data ?? []);
+type Props =
+  | { idArea: number; idSector?: never; data?: never }
+  | { idArea?: never; idSector: number; data?: never }
+  | { idArea?: never; idSector?: never; data: Data };
 
-  useEffect(() => {
-    if (idArea > 0 || idSector > 0) {
-      getGradeDistribution(accessToken, idArea, idSector).then((res) => {
-        setGradeDistribution(res);
-      });
-    }
-  }, [accessToken, idArea, idSector]);
+const ChartGradeDistribution = ({
+  idArea = 0,
+  idSector = 0,
+  data = undefined,
+}: Props) => {
+  const { data: gradeDistribution } = useGradeDistribution(
+    idArea,
+    idSector,
+    data || undefined,
+  );
 
   if (!gradeDistribution) {
     return <Loading />;
   }
+
   const maxValue = Math.max(
     ...gradeDistribution.map((d) => {
       return d.num;


### PR DESCRIPTION
Create a `useGradeDistribution(..)` hook to migrate the grade distribution fetching to the `@tanstack/react-query` data-fetching setup for enhanced caching & so on.

This also changes the API of the `ChartGradeDistribution` component to get rid of the unnecessary props, so it is more obvious how to use it.