### PR TITLE
Migrate getUserSearch to react-query

### DIFF
--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -510,3 +510,9 @@ export function useGradeDistribution(
     },
   );
 }
+
+export function useUserSearch(value: string = "") {
+  return useData<Success<"getUsersSearch">>(`/users/search?value=${value}`, {
+    queryKey: [`/users/search`, { value }],
+  });
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,6 @@ export {
   moveMedia,
   getPermissions,
   getSvgEdit,
-  getUserSearch,
   downloadUsersTicks,
   postComment,
   postPermissions,

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -122,22 +122,6 @@ export function getSvgEdit(
     });
 }
 
-export function getUserSearch(
-  accessToken: string | null,
-  value: string,
-): Promise<components["schemas"]["UserSearch"][]> {
-  return makeAuthenticatedRequest(
-    accessToken,
-    `/users/search?value=${value}`,
-    null,
-  )
-    .then((data) => data.json())
-    .catch((error) => {
-      console.warn(error);
-      return null;
-    });
-}
-
 export function downloadUsersTicks(accessToken: string | null) {
   return downloadXlsx(accessToken, `/users/ticks`);
 }

--- a/src/components/common/user-selector/user-selector.tsx
+++ b/src/components/common/user-selector/user-selector.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, ComponentProps } from "react";
-import { useAuth0 } from "@auth0/auth0-react";
+import React, { ComponentProps } from "react";
 import CreatableSelect from "react-select/creatable";
-import { getUserSearch } from "./../../../api";
+import { useUserSearch } from "./../../../api";
 import { components } from "../../../@types/buldreinfo/swagger";
 
 type User = components["schemas"]["User"];
@@ -15,23 +14,6 @@ type MultiUserProps = {
 type SingleUserProps = {
   onUserUpdated: (user: User) => void;
   placeholder: string;
-};
-
-const useUsers = () => {
-  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const [options, setOptions] = useState<User[]>([]);
-  useEffect(() => {
-    if (!isLoading) {
-      const update = async () => {
-        const accessToken = isAuthenticated
-          ? await getAccessTokenSilently()
-          : null;
-        getUserSearch(accessToken ?? "", "").then((res) => setOptions(res));
-      };
-      update();
-    }
-  }, [getAccessTokenSilently, isAuthenticated, isLoading]);
-  return options;
 };
 
 const UserSelect = (
@@ -49,7 +31,7 @@ const UserSelect = (
         > & { isMulti: false }
       >,
 ) => {
-  const options = useUsers();
+  const { data: options = [] } = useUserSearch();
 
   return (
     <div style={{ position: "relative", width: "100%" }}>


### PR DESCRIPTION
Migrate the `getUserSearch()` operation to `useUserSearch()` to benefit from the caching of the data-fetching library. This makes every user selector _substantially_ faster to load.