### PR TITLE
chore: Fix typing around SVG parsing

### DIFF
--- a/src/components/SvgViewer/SvgRoute.tsx
+++ b/src/components/SvgViewer/SvgRoute.tsx
@@ -31,8 +31,7 @@ export const SvgRoute = ({
   setProblemIdHovered,
 }: Props) => {
   const navigate = useNavigate();
-  const path: any = parseSVG(svg.path);
-  makeAbsolute(path); // Note: mutates the commands in place!
+  const path = makeAbsolute(parseSVG(svg.path)); // Note: mutates the commands in place!
 
   let gClassName = "buldreinfo-svg-pointer";
   if (optProblemId || problemIdHovered) {


### PR DESCRIPTION
Utilize the `@types/svg-path-parser` package to add helpful typing to the parsed SVG output.

This also shifts around some code to make it a _very little_ bit easier to follow.