### PR TITLE
feat: Use a RangeSlider for FA year filtering

### DIFF
--- a/src/components/Problems/reducer.ts
+++ b/src/components/Problems/reducer.ts
@@ -4,15 +4,15 @@ import { useGrades } from "../common/meta/meta";
 import { itemLocalStorage } from "../../utils/use-local-storage";
 import { components } from "../../@types/buldreinfo/swagger";
 
-export type State = {
-  visible: boolean;
-  gradeDifficultyLookup: Record<string, number>;
-  totalRegions: number;
-  totalAreas: number;
-  totalSectors: number;
-  totalProblems: number;
-  unfilteredData: components["schemas"]["Toc"];
-} & {
+type FilterResults = {
+  filteredData: components["schemas"]["Toc"];
+  filteredRegions: number;
+  filteredAreas: number;
+  filteredSectors: number;
+  filteredProblems: number;
+};
+
+type FilterInputs = {
   filterRegionIds: Record<number, true>;
   filterAreaIds: Record<number, true>;
   filterAreaOnlySunOnWallAt: number | undefined;
@@ -24,18 +24,27 @@ export type State = {
   filterFaYearHigh: number | undefined;
   filterTypes: Record<number, boolean> | undefined;
   filterPitches:
-    | { "Single-pitch": boolean; "Multi-pitch": boolean }
+    | {
+        "Single-pitch": boolean;
+        "Multi-pitch": boolean;
+      }
     | undefined;
   filterHideTicked: boolean | undefined;
   filterOnlyAdmin: boolean | undefined;
   filterOnlySuperAdmin: boolean | undefined;
-  filteredData: components["schemas"]["Toc"];
-
-  filteredRegions: number;
-  filteredAreas: number;
-  filteredSectors: number;
-  filteredProblems: number;
 };
+
+type FilterState = FilterInputs & FilterResults;
+
+export type State = {
+  visible: boolean;
+  gradeDifficultyLookup: Record<string, number>;
+  totalRegions: number;
+  totalAreas: number;
+  totalSectors: number;
+  totalProblems: number;
+  unfilteredData: components["schemas"]["Toc"];
+} & FilterState;
 
 export type ResetField =
   | "all"
@@ -75,11 +84,12 @@ export type Update =
       gradeDifficultyLookup: State["gradeDifficultyLookup"];
     }
   | { action: "set-grades"; low: string; high: string }
-  | ({ action: "set-fa-year" } & ({ low: number } | { high: number }))
+  | { action: "set-fa-years"; low: number; high: number }
   | { action: "set-hide-ticked"; checked: boolean }
   | { action: "set-only-admin"; checked: boolean }
   | { action: "set-only-super-admin"; checked: boolean }
   | ({ action: "set-grade" } & ({ low: string } | { high: string }))
+  | ({ action: "set-fa-year" } & ({ low: number } | { high: number }))
   | { action: "close-filter" }
   | { action: "open-filter" }
   | { action: "toggle-filter" }
@@ -448,6 +458,15 @@ const reducer = (state: State, update: Update): State => {
         ...state,
         filterGradeLow: low ?? state.filterGradeLow ?? undefined,
         filterGradeHigh: high ?? state.filterGradeHigh ?? undefined,
+      };
+    }
+
+    case "set-fa-years": {
+      const { low, high } = update;
+      return {
+        ...state,
+        filterFaYearLow: low,
+        filterFaYearHigh: high,
       };
     }
 

--- a/src/components/common/FilterForm/FilterForm.tsx
+++ b/src/components/common/FilterForm/FilterForm.tsx
@@ -24,6 +24,7 @@ import { useFilter } from "./context";
 import { HeaderButtons } from "../HeaderButtons";
 import { ResetField } from "../../Problems/reducer";
 import { neverGuard } from "../../../utils/neverGuard";
+import { YearSelect } from "./YearSelect";
 
 const CLIMBING_OPTIONS = [
   {
@@ -155,8 +156,6 @@ export const FilterForm = () => {
     filterSectorWallDirections,
     filterOnlyAdmin,
     filterOnlySuperAdmin,
-    filterFaYearLow,
-    filterFaYearHigh,
     filterHideTicked,
     filterPitches,
     filterTypes,
@@ -193,15 +192,6 @@ export const FilterForm = () => {
     { key: 21, text: "21:00", value: 21 },
     { key: 22, text: "22:00", value: 22 },
     { key: 23, text: "23:00", value: 23 },
-  ];
-
-  const faYearOptions = [
-    { key: -1, text: "<disabled>", value: -1 },
-    ...meta.faYears.map((year) => ({
-      key: year,
-      text: year,
-      value: year,
-    })),
   ];
 
   const {
@@ -291,43 +281,10 @@ export const FilterForm = () => {
           </Form.Group>
         </>
       )}
-      <GroupHeader title="FA Year" reset="fa-year" />
-      <Form.Group inline>
-        <Form.Field>
-          From:{" "}
-          <Dropdown
-            floating
-            scrolling
-            inline
-            options={faYearOptions}
-            value={filterFaYearLow || -1}
-            onChange={(_, { value }) => {
-              dispatch?.({
-                action: "set-fa-year",
-                low: value as number,
-              });
-            }}
-          />
-          .
-        </Form.Field>
-        <Form.Field>
-          To:{" "}
-          <Dropdown
-            floating
-            scrolling
-            inline
-            options={faYearOptions}
-            value={filterFaYearHigh || -1}
-            onChange={(_, { value }) => {
-              dispatch?.({
-                action: "set-fa-year",
-                high: value as number,
-              });
-            }}
-          />
-          .
-        </Form.Field>
-      </Form.Group>
+      <Form.Field>
+        <GroupHeader title="First Ascent Year" reset="fa-year" />
+        <YearSelect />
+      </Form.Field>
       <GroupHeader title="Options" reset="options" />
       <Form.Group inline>
         <Form.Field>

--- a/src/components/common/FilterForm/YearSelect/YearSelect.tsx
+++ b/src/components/common/FilterForm/YearSelect/YearSelect.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import RangeSlider from "react-range-slider-input";
+import "react-range-slider-input/dist/style.css";
+import { useFilter } from "../context";
+import { Dropdown } from "semantic-ui-react";
+import { useFaYears } from "../../meta";
+
+// TODO: This was created by copy-and-pasting the GradeSelect component and then
+//       simplifying (because the data is much less complex). Is there an
+//       opportunity for creating a generic component here? Or would it just
+//       wind up being more trouble than it's worth with all the data mapping
+//       and different state updates and high-on-left vs high-on-right?
+export const YearSelect = () => {
+  const { filterFaYearLow, filterFaYearHigh, dispatch } = useFilter();
+  const faYears = useFaYears();
+
+  const max = Math.max(faYears.length - 1, 0);
+  const low = filterFaYearLow || faYears[0];
+  const high = filterFaYearHigh || faYears[max];
+
+  return (
+    <div>
+      <div style={{ marginBottom: 20 }}>
+        <RangeSlider
+          key={`${0}-${max}`}
+          min={faYears[0]}
+          max={faYears[max]}
+          value={[low, high]}
+          onInput={([l, h]) => {
+            dispatch({
+              action: "set-fa-years",
+              low: l ?? faYears[0],
+              high: h ?? faYears[max],
+            });
+          }}
+          disabled={max === 0}
+        />
+      </div>
+      <div
+        style={{ display: "flex", flexDirection: "row", alignItems: "start" }}
+      >
+        <div style={{ display: "flex", flex: 1, justifyContent: "flex-start" }}>
+          <Dropdown
+            text={String(low)}
+            value={low}
+            scrolling
+            pointing="top left"
+            options={faYears
+              .filter((value) => value < high)
+              .map((year) => ({ key: year, text: String(year), value: year }))}
+            onChange={(_, { value }) => {
+              dispatch({
+                action: "set-fa-year",
+                low: +value,
+              });
+            }}
+          />
+        </div>
+        <div style={{ display: "flex", flex: 1, justifyContent: "flex-end" }}>
+          <Dropdown
+            text={String(high)}
+            value={high}
+            scrolling
+            pointing="top right"
+            options={faYears
+              .filter((value) => value > low)
+              .map((year) => ({ key: year, text: String(year), value: year }))}
+            onChange={(_, { value }) => {
+              dispatch({
+                action: "set-fa-year",
+                high: +value,
+              });
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/common/FilterForm/YearSelect/index.ts
+++ b/src/components/common/FilterForm/YearSelect/index.ts
@@ -1,0 +1,1 @@
+export { YearSelect } from "./YearSelect";

--- a/src/components/common/meta/index.ts
+++ b/src/components/common/meta/index.ts
@@ -1,1 +1,1 @@
-export { MetaProvider, useMeta } from "./meta";
+export { MetaProvider, useFaYears, useGrades, useMeta } from "./meta";

--- a/src/components/common/meta/meta.tsx
+++ b/src/components/common/meta/meta.tsx
@@ -96,8 +96,17 @@ export const useGrades = () => {
   };
 };
 
+export const useFaYears = () => {
+  return useMeta().faYears;
+};
+
 export const MetaProvider = ({ children }: Props) => {
-  const { data: meta } = useData<Metadata>(`/meta`);
+  const { data: meta } = useData<Metadata>(`/meta`, {
+    select: (data) => {
+      data.faYears.sort((a, b) => a - b);
+      return data;
+    },
+  });
 
   return (
     <MetaContext.Provider value={meta || DEFAULT_VALUE}>


### PR DESCRIPTION
The first ascent year filter control is just like the grades: a ranged value. This change follows the convention already introduced by the grades, and uses a `RangeSlider` for the input, instead of separate drop-down inputs.

There's _possibly_ an opportunity for code reuse, but it gets a bit tricky -- while the controls look visually similar, they have different behaviors internally. Combining them might make sense, but it also might not. I left a comment in there for a future explorer to consider on a rainy day :)