### PR TITLE
chore: Fix some strict-mode TypeScript errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/isomorphic-fetch": "^0.0.39",
     "@types/leaflet": "^1.9.12",
     "@types/react": "^18.3.3",
+    "@types/react-helmet": "^6.1.11",
     "@types/svg-path-parser": "^1.1.6",
     "@types/swagger-ui-react": "^4.18.3",
     "babel-loader": "^9.1.3",

--- a/src/components/Problems/Problems.tsx
+++ b/src/components/Problems/Problems.tsx
@@ -119,68 +119,83 @@ export const Problems = ({ filterOpen }: Props) => {
     things,
   );
 
-  const areas: FilterArea[] = filteredData?.regions?.flatMap((region) => {
-    return region.areas.map((area) => ({
-      id: area.id,
-      lockedAdmin: !!area.lockedAdmin,
-      lockedSuperadmin: !!area.lockedSuperadmin,
-      sunFromHour: area.sunFromHour,
-      sunToHour: area.sunToHour,
-      name: area.name,
-      lat: area.coordinates?.latitude,
-      lng: area.coordinates?.longitude,
-      sectors: area.sectors.map((sector) => ({
-        id: sector.id,
-        lockedAdmin: !!sector.lockedAdmin,
-        lockedSuperadmin: !!sector.lockedSuperadmin,
-        name: sector.name,
-        lat: sector.parking?.latitude,
-        lng: sector.parking?.longitude,
-        outline: sector.outline,
-        wallDirectionCalculated: sector.wallDirectionCalculated,
-        wallDirectionManual: sector.wallDirectionManual,
-        problems: sector.problems.map((problem) => {
-          const ascents =
-            problem.numTicks > 0 &&
-            problem.numTicks + (problem.numTicks == 1 ? " ascent" : " ascents");
-          let typeAscents;
-          if (isClimbing) {
-            let t = problem.t.subType;
-            if (problem.numPitches > 1)
-              t += ", " + problem.numPitches + " pitches";
-            if (ascents) {
-              typeAscents = " (" + t + ", " + ascents + ") ";
-            } else {
-              typeAscents = " (" + t + ") ";
-            }
-          } else if (!isClimbing) {
-            if (ascents) {
-              typeAscents = " (" + ascents + ") ";
-            } else {
-              typeAscents = " ";
-            }
-          }
-          const text = [problem.fa, typeAscents].filter(Boolean).join(" ");
-          return {
-            id: problem.id,
-            broken: problem.broken,
-            lockedAdmin: !!problem.lockedAdmin,
-            lockedSuperadmin: !!problem.lockedSuperadmin,
-            name: problem.name,
-            lat: problem.coordinates?.latitude,
-            lng: problem.coordinates?.longitude,
-            nr: problem.nr,
-            grade: problem.grade,
-            stars: problem.stars,
-            ticked: problem.ticked,
-            text: text,
-            subText: problem.description,
-            faYear: problem.faYear,
-          };
-        }),
-      })),
-    }));
-  });
+  const areas: FilterArea[] =
+    filteredData?.regions?.flatMap((region) => {
+      return (
+        region.areas?.map(
+          (area) =>
+            ({
+              id: area.id ?? 0,
+              lockedAdmin: !!area.lockedAdmin,
+              lockedSuperadmin: !!area.lockedSuperadmin,
+              sunFromHour: area.sunFromHour ?? 0,
+              sunToHour: area.sunToHour ?? 0,
+              name: area.name ?? "",
+              lat: area.coordinates?.latitude,
+              lng: area.coordinates?.longitude,
+              sectors:
+                area.sectors?.map(
+                  (sector) =>
+                    ({
+                      id: sector.id ?? 0,
+                      lockedAdmin: !!sector.lockedAdmin,
+                      lockedSuperadmin: !!sector.lockedSuperadmin,
+                      name: sector.name ?? "",
+                      lat: sector.parking?.latitude,
+                      lng: sector.parking?.longitude,
+                      outline: sector.outline,
+                      wallDirectionCalculated:
+                        sector.wallDirectionCalculated ?? {},
+                      wallDirectionManual: sector.wallDirectionManual ?? {},
+                      problems:
+                        sector.problems?.map((problem) => {
+                          const ascents =
+                            problem.numTicks &&
+                            problem.numTicks +
+                              (problem.numTicks == 1 ? " ascent" : " ascents");
+                          let typeAscents;
+                          if (isClimbing) {
+                            let t = problem.t?.subType;
+                            if (problem.numPitches && problem.numPitches > 1)
+                              t += ", " + problem.numPitches + " pitches";
+                            if (ascents) {
+                              typeAscents = " (" + t + ", " + ascents + ") ";
+                            } else {
+                              typeAscents = " (" + t + ") ";
+                            }
+                          } else if (!isClimbing) {
+                            if (ascents) {
+                              typeAscents = " (" + ascents + ") ";
+                            } else {
+                              typeAscents = " ";
+                            }
+                          }
+                          const text = [problem.fa, typeAscents]
+                            .filter(Boolean)
+                            .join(" ");
+                          return {
+                            id: problem.id ?? 0,
+                            broken: problem.broken ?? "",
+                            lockedAdmin: !!problem.lockedAdmin,
+                            lockedSuperadmin: !!problem.lockedSuperadmin,
+                            name: problem.name ?? "",
+                            lat: problem.coordinates?.latitude,
+                            lng: problem.coordinates?.longitude,
+                            nr: problem.nr ?? 0,
+                            grade: problem.grade ?? "",
+                            stars: problem.stars,
+                            ticked: problem.ticked,
+                            text: text,
+                            subText: problem.description,
+                            faYear: problem.faYear ?? 0,
+                          } satisfies FilterProblem;
+                        }) ?? [],
+                    }) satisfies FilterSector,
+                ) ?? [],
+            }) satisfies FilterArea,
+        ) ?? []
+      );
+    }) ?? [];
 
   return (
     <FilterContext.Provider value={{ ...state, dispatch }}>

--- a/src/components/common/FilterForm/FilterForm.tsx
+++ b/src/components/common/FilterForm/FilterForm.tsx
@@ -101,7 +101,7 @@ const ICONS: Record<AreaSizeState, SemanticICONS | undefined> = {
 };
 
 const useSizing = () => {
-  const ref = useRef<HTMLDivElement>();
+  const ref = useRef<HTMLDivElement | null>(null);
   const [status, setStatus] = useState<AreaSizeState>("show-some");
 
   useLayoutEffect(() => {
@@ -249,7 +249,7 @@ export const FilterForm = () => {
                     dispatch?.({
                       action: "toggle-types",
                       option: discipline.value,
-                      checked,
+                      checked: !!checked,
                     });
                   }}
                   style={{ marginRight: 10 }}
@@ -272,7 +272,7 @@ export const FilterForm = () => {
                     dispatch?.({
                       action: "toggle-pitches",
                       option: option.value,
-                      checked,
+                      checked: !!checked,
                     });
                   }}
                 />
@@ -293,7 +293,7 @@ export const FilterForm = () => {
             checked={!!filterHideTicked}
             disabled={!meta.isAuthenticated}
             onChange={(_, { checked }) =>
-              dispatch?.({ action: "set-hide-ticked", checked })
+              dispatch?.({ action: "set-hide-ticked", checked: !!checked })
             }
           />
         </Form.Field>
@@ -303,7 +303,7 @@ export const FilterForm = () => {
               label="Only admin"
               checked={!!filterOnlyAdmin}
               onChange={(_, { checked }) => {
-                dispatch?.({ action: "set-only-admin", checked });
+                dispatch?.({ action: "set-only-admin", checked: !!checked });
               }}
             />
           </Form.Field>
@@ -314,7 +314,10 @@ export const FilterForm = () => {
               label="Only superadmin"
               checked={!!filterOnlySuperAdmin}
               onChange={(_, { checked }) => {
-                dispatch?.({ action: "set-only-super-admin", checked });
+                dispatch?.({
+                  action: "set-only-super-admin",
+                  checked: !!checked,
+                });
               }}
             />
           </Form.Field>
@@ -334,7 +337,7 @@ export const FilterForm = () => {
                     dispatch?.({
                       action: "toggle-sector-wall-directions",
                       option: option.value,
-                      checked,
+                      checked: !!checked,
                     });
                   }}
                   style={{ marginRight: 10 }}
@@ -381,19 +384,21 @@ export const FilterForm = () => {
           </Form.Group>
         </>
       )}
-      {unfilteredData?.regions?.length > 1 && (
+      {(unfilteredData?.regions?.length ?? 0) > 1 && (
         <>
           <GroupHeader
             title="Regions"
             reset="regions"
-            buttons={[
+            buttons={
               regionContainerButton
-                ? {
-                    icon: regionContainerButton,
-                    onClick: regionContainerAction,
-                  }
-                : undefined,
-            ]}
+                ? [
+                    {
+                      icon: regionContainerButton,
+                      onClick: regionContainerAction,
+                    },
+                  ]
+                : undefined
+            }
           />
           <Form.Group inline>
             <div
@@ -404,16 +409,16 @@ export const FilterForm = () => {
               }}
               ref={regionContainerRef}
             >
-              {unfilteredData?.regions?.map((region) => (
-                <Form.Field key={region.id}>
+              {unfilteredData?.regions?.map(({ id = 0, name = "" }) => (
+                <Form.Field key={id}>
                   <Checkbox
-                    label={region.name}
-                    checked={!!filterRegionIds[region.id]}
+                    label={name}
+                    checked={!!filterRegionIds[id]}
                     onChange={(_, { checked }) =>
                       dispatch({
                         action: "toggle-region",
-                        regionId: region.id,
-                        enabled: checked,
+                        regionId: id,
+                        enabled: !!checked,
                       })
                     }
                     style={{ marginRight: 10 }}
@@ -427,11 +432,11 @@ export const FilterForm = () => {
       <GroupHeader
         title="Areas"
         reset="areas"
-        buttons={[
+        buttons={
           areaContainerButton
-            ? { icon: areaContainerButton, onClick: areaContainerAction }
-            : undefined,
-        ]}
+            ? [{ icon: areaContainerButton, onClick: areaContainerAction }]
+            : undefined
+        }
       />
       <Form.Group inline>
         <div
@@ -443,16 +448,16 @@ export const FilterForm = () => {
           ref={areaContainerRef}
         >
           {unfilteredData?.regions?.map((region) =>
-            region.areas.map((area) => (
-              <Form.Field key={area.id}>
+            region.areas?.map(({ id = 0, name = "" }) => (
+              <Form.Field key={id}>
                 <Checkbox
-                  label={area.name}
-                  checked={!!filterAreaIds[area.id]}
+                  label={name}
+                  checked={!!filterAreaIds[id]}
                   onChange={(_, { checked }) =>
                     dispatch({
                       action: "toggle-area",
-                      areaId: area.id,
-                      enabled: checked,
+                      areaId: id,
+                      enabled: !!checked,
                     })
                   }
                 />

--- a/src/components/common/FilterForm/YearSelect/YearSelect.tsx
+++ b/src/components/common/FilterForm/YearSelect/YearSelect.tsx
@@ -48,7 +48,7 @@ export const YearSelect = () => {
             options={faYears
               .filter((value) => value < high)
               .map((year) => ({ key: year, text: String(year), value: year }))}
-            onChange={(_, { value }) => {
+            onChange={(_, { value = 0 }) => {
               dispatch({
                 action: "set-fa-year",
                 low: +value,
@@ -65,7 +65,7 @@ export const YearSelect = () => {
             options={faYears
               .filter((value) => value > low)
               .map((year) => ({ key: year, text: String(year), value: year }))}
-            onChange={(_, { value }) => {
+            onChange={(_, { value = 0 }) => {
               dispatch({
                 action: "set-fa-year",
                 high: +value,

--- a/src/components/common/TableOfContents/TableOfContents.tsx
+++ b/src/components/common/TableOfContents/TableOfContents.tsx
@@ -59,7 +59,7 @@ export type Props = {
 };
 
 export const TableOfContents = ({ areas, header, subHeader }: Props) => {
-  const areaRefs = useRef({});
+  const areaRefs = useRef<Record<number, HTMLElement | null>>({});
 
   if (!areas) {
     return <i>No results match your search criteria.</i>;
@@ -74,7 +74,7 @@ export const TableOfContents = ({ areas, header, subHeader }: Props) => {
             <List.Item
               as="a"
               onClick={() =>
-                areaRefs.current[area.id].scrollIntoView({ block: "start" })
+                areaRefs.current[area.id]?.scrollIntoView({ block: "start" })
               }
             >
               {area.name}
@@ -138,12 +138,12 @@ export const TableOfContents = ({ areas, header, subHeader }: Props) => {
                           )}
                         </Link>{" "}
                         {problem.grade}{" "}
-                        {problem.stars > 0 && (
+                        {problem.stars ? (
                           <Stars
                             numStars={problem.stars}
                             includeNoRating={false}
                           />
-                        )}
+                        ) : null}
                         {problem.text && <small>{problem.text} </small>}
                         {problem.broken && <u>{problem.broken} </u>}
                         {problem.subText && (

--- a/src/components/common/meta/meta.tsx
+++ b/src/components/common/meta/meta.tsx
@@ -82,7 +82,7 @@ export const useGrades = () => {
   const { grades } = useMeta();
   const [gradesLowHigh, indexMapping] = useMemo(() => {
     const easyToHard = grades.map(({ grade }) => grade).reverse();
-    const indexMapping = easyToHard.reduce(
+    const indexMapping = easyToHard.reduce<Record<string, number>>(
       (acc, grade, i) => ({ ...acc, [grade]: i }),
       {},
     );

--- a/src/react-range-slider-input.d.ts
+++ b/src/react-range-slider-input.d.ts
@@ -1,0 +1,105 @@
+// https://github.com/n3r4zzurr0/react-range-slider-input/issues/7#issuecomment-1736988329
+
+declare module "react-range-slider-input" {
+  import type { FC } from "react";
+
+  export type Orientation = "horizontal" | "vertical";
+  export type Step = number | "any";
+
+  export type InputEvent = [number, number];
+  export type InputEventHandler = (event: InputEvent) => void;
+
+  export interface ReactRangeSliderInputProps {
+    /* @default null
+     * Identifier string (id attribute value) to be passed to the range slider element.
+     * */
+    id?: string;
+
+    /* @default null
+     * String of classes to be passed to the range slider element.
+     * */
+    className?: string;
+
+    /* @default 0
+     * Number that specifies the lowest value in the range of permitted values.
+     * Its value must be less than that of max.
+     * */
+    min?: number;
+
+    /* @default 100
+     * Number that specifies the greatest value in the range of permitted values.
+     * Its value must be greater than that of min.
+     * */
+    max?: number;
+
+    /* @default 1
+     * Number that specifies the amount by which the slider value(s) will change upon user interaction.
+     * Other than numbers, the value of step can be a string value of any.
+     * */
+    step?: number | "any";
+
+    /* @default [25, 75]
+     * Array of two numbers that specify the default values of the lower and upper offsets of the range slider element respectively.
+     * If set, the range slider will be rendered as an uncontrolled element. To render it as a controlled element, set the value property.
+     * */
+    defaultValue?: [number, number];
+
+    /* @default []
+     * Array of two numbers that specify the values of the lower and upper offsets of the range slider element respectively.
+     * If set, the range slider will be rendered as a controlled element.
+     * */
+    value?: [number, number];
+
+    /*
+     * Function to be called when there is a change in the value(s) of range sliders upon user interaction.
+     * */
+    onInput?: InputEventHandler;
+
+    /*
+     * Function to be called when the pointerdown event is triggered for any of the thumbs.
+     * */
+    onThumbDragStart?: () => void;
+
+    /*
+     * Function to be called when the pointerup event is triggered for any of the thumbs.
+     * */
+    onThumbDragEnd?: () => void;
+
+    /*
+     * Function to be called when the pointerdown event is triggered for the range.
+     * */
+    onRangeDragStart?: () => void;
+
+    /*
+     * Function to be called when the pointerup event is triggered for the range.
+     * */
+    onRangeDragEnd?: () => void;
+
+    /* @default false
+     * Boolean that specifies if the range slider element is disabled or not.
+     * */
+    disabled?: boolean;
+
+    /* @default false
+     * Boolean that specifies if the range is slidable or not.
+     * */
+    rangeSlideDisabled?: boolean;
+
+    /* @default [false, false]
+     * Array of two Booleans which specify if the lower and upper thumbs are disabled or not, respectively.
+     * If only one Boolean value is passed instead of an array, the value will apply to both thumbs.
+     * */
+    thumbsDisabled?: [boolean, boolean];
+
+    /* @default 'horizontal'
+     * String that specifies the axis along which the user interaction is to be registered.
+     * By default, the range slider element registers the user interaction along the X-axis.
+     * It takes two different values: horizontal and vertical.
+     * */
+    orientation?: Orientation;
+  }
+
+  const ReactRangeSliderInput: FC<ReactRangeSliderInputProps>;
+
+  export default ReactRangeSliderInput;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,6 +3519,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
+"@types/react-helmet@^6.1.11":
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.11.tgz#8cafcafff38f75361f451563ba7b406b0c5d3907"
+  integrity sha512-0QcdGLddTERotCXo3VFlUSWO3ztraw8nZ6e3zJSgG7apwV5xt+pJUS8ewPBqT4NYB1optGLprNQzFleIY84u/g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.0":
   version "4.4.10"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.10.tgz#6ee71127bdab1f18f11ad8fb3322c6da27c327ac"
@@ -9785,16 +9792,7 @@ streamx@^2.13.0, streamx@^2.15.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9826,14 +9824,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10870,16 +10861,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
We (currently) don't use TypeScript in strict mode, which results in a lot of _probably_-okay errors slipping through. However, it leads to more of a development struggle as static analysis is harder.

For this change, I uncommented `// strict: true,` in the `tsconfig.json` file and started fixing errors. For this pass, I focused on the errors in the general vicinity of the `/problems` route.

More to come in other PRs :)