### PR TITLE
fix: Show a loading indicator on /problems

### DIFF
--- a/src/components/Problems/Problems.tsx
+++ b/src/components/Problems/Problems.tsx
@@ -103,7 +103,7 @@ export const Problems = ({ filterOpen }: Props) => {
     visible,
   } = state;
 
-  if (!loadedData) {
+  if (status === "pending") {
     return <Loading />;
   } else if (totalProblems === 0) {
     return <Segment>No data</Segment>;


### PR DESCRIPTION
The `/problems` component was written to show a loading spinner while fetching the data .. but the check for "are we loading?" was incorrect.

This change fixes the check so that we get the appropriate UI again.