### PR TITLE
chore: Fix TS strict errors around ProblemEdit

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -95,9 +95,9 @@ export function numberWithCommas(number: number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
-export function convertFromDateToString(date: Date | null): string | null {
+export function convertFromDateToString(date: Date | null): string | undefined {
   if (!date) {
-    return null;
+    return undefined;
   }
   const d = date.getDate();
   const m = date.getMonth() + 1;

--- a/src/components/common/problem-section/problem-section.tsx
+++ b/src/components/common/problem-section/problem-section.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from "react";
+import React, { ComponentProps, useCallback, useState } from "react";
 import { Form, Input, Dropdown } from "semantic-ui-react";
 import { components } from "../../../@types/buldreinfo/swagger";
 import { useMeta } from "../meta";
 
+type ProblemSections = components["schemas"]["ProblemSection"][];
+
 type Props = {
-  sections: components["schemas"]["ProblemSection"][];
-  onSectionsUpdated: (
-    sections: components["schemas"]["ProblemSection"][],
-  ) => void;
+  sections: ProblemSections;
+  onSectionsUpdated: (sections: ProblemSections) => void;
 };
 
 const ProblemSection = ({
@@ -17,32 +17,41 @@ const ProblemSection = ({
   const { grades } = useMeta();
   const [sections, setSections] = useState(initSections);
 
-  function onNumberOfSectionsChange(e, { value }) {
-    const num = parseInt(value);
-    let newSections = null;
-    if (num > 1) {
-      newSections = sections ? [...sections] : [];
-      while (num > newSections.length) {
-        newSections.push({
-          id: newSections.length * -1,
-          nr: newSections.length + 1,
-          grade: "n/a",
-          description: null,
-        });
+  const onNumberOfSectionsChange: NonNullable<
+    ComponentProps<typeof Dropdown>["onChange"]
+  > = useCallback(
+    (e, { value }) => {
+      if (value === undefined) {
+        return;
       }
-      while (num < newSections.length) {
-        newSections.pop();
+
+      const num = +value;
+      let newSections: ProblemSections = [];
+      if (num > 1) {
+        newSections = sections ? [...sections] : [];
+        while (num > newSections.length) {
+          newSections.push({
+            id: newSections.length * -1,
+            nr: newSections.length + 1,
+            grade: "n/a",
+            description: undefined,
+          });
+        }
+        while (num < newSections.length) {
+          newSections.pop();
+        }
       }
-    }
-    onSectionsUpdated(newSections);
-    setSections(newSections);
-  }
+      onSectionsUpdated(newSections);
+      setSections(newSections);
+    },
+    [onSectionsUpdated, sections],
+  );
 
   return (
     <>
       <Dropdown
         selection
-        value={sections ? sections.length : 1}
+        value={Math.max(sections?.length ?? 0, 1)}
         onChange={onNumberOfSectionsChange}
         options={[
           { key: 1, value: 1, text: 1 },

--- a/src/components/common/user-selector/user-selector.tsx
+++ b/src/components/common/user-selector/user-selector.tsx
@@ -4,6 +4,7 @@ import { useUserSearch } from "./../../../api";
 import { components } from "../../../@types/buldreinfo/swagger";
 
 type UserOption = {
+  value?: string | number;
   label?: string;
 } & components["schemas"]["User"];
 
@@ -72,7 +73,7 @@ export const UserSelector = ({
       isMulti={false}
       placeholder={placeholder}
       onChange={onUserUpdated}
-      defaultValue={defaultValue && { label: defaultValue }}
+      defaultValue={{ label: defaultValue }}
     />
   );
 };


### PR DESCRIPTION
Fix another batch of errors when `strict: true` is enabled in `tsconfig.json` - this time, it's focused around `ProblemEdit`.

There should be no change in functionality - only fewer TS errors when strictmode is enabled. (However, it's hard to guarantee that - there's a lot of functionality, and very few tests)