### PR TITLE
chore: Fix TS strict errors around SectorEdit

### DIFF
--- a/src/components/SectorEdit/PolylineEditor.tsx
+++ b/src/components/SectorEdit/PolylineEditor.tsx
@@ -12,10 +12,10 @@ import { useCallback } from "react";
 import { DropzoneOptions, useDropzone } from "react-dropzone";
 import { components } from "../../@types/buldreinfo/swagger";
 import {
-  convertGpxToCoordinates,
-  convertTcxToCoordinates,
   calculateDistanceBetweenCoordinates,
+  parsers,
 } from "../common/leaflet/geo-utils";
+import { captureMessage } from "@sentry/react";
 
 type Props = {
   coordinates: components["schemas"]["Coordinates"][];
@@ -30,44 +30,68 @@ export const PolylineEditor = ({
   onChange,
   upload,
 }: Props) => {
-  const onDrop: DropzoneOptions["onDrop"] = useCallback(
-    (files) => {
-      if (files?.length !== 0) {
-        const file = files[0] as any; // Missing ts-definition
-        const reader = new FileReader();
-        reader.onload = (e) => {
-          let coords;
-          if (file.path.toLowerCase().endsWith(".gpx")) {
-            coords = convertGpxToCoordinates(e.target?.result as string);
-          } else {
-            coords = convertTcxToCoordinates(e.target?.result as string);
-          }
-          if (coords?.length >= 2 && parking) {
-            // Reverse order if approach is drawn from crag to parking
-            const distanceFromParkingToFirstPoint =
-              calculateDistanceBetweenCoordinates(
-                parking.latitude,
-                parking.longitude,
-                coords[0].latitude,
-                coords[0].longitude,
-              );
-            const distanceFromParkingToLastPoint =
-              calculateDistanceBetweenCoordinates(
-                parking.latitude,
-                parking.longitude,
-                coords[coords.length - 1].latitude,
-                coords[coords.length - 1].longitude,
-              );
-            if (
-              distanceFromParkingToLastPoint < distanceFromParkingToFirstPoint
-            ) {
-              coords.reverse();
-            }
-          }
-          onChange(coords);
-        };
-        reader.readAsText(file);
+  const onDrop = useCallback(
+    (files: (File & { path: string })[]) => {
+      if (files?.length === 0) {
+        return;
       }
+
+      const file = files[0];
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const match = file.path.toLowerCase().match(/\.([a-z]+)$/);
+        if (!match) {
+          captureMessage("Could not extract file extension");
+          return;
+        }
+        const extension = match[1];
+
+        const parser = parsers[extension];
+        if (!parser) {
+          captureMessage("No defined parser for file", {
+            extra: { extension: extension },
+          });
+          return;
+        }
+
+        const coords = parser(e.target?.result as string);
+        if (!coords) {
+          captureMessage("Could not parse file", {
+            extra: { extension: extension },
+          });
+          return;
+        }
+
+        if (coords.length === 0) {
+          captureMessage("Parsed empty coordinates", { extra: { extension } });
+          return;
+        }
+
+        if (coords.length >= 2 && parking) {
+          // Reverse order if approach is drawn from crag to parking
+          const distanceFromParkingToFirstPoint =
+            calculateDistanceBetweenCoordinates(
+              parking.latitude ?? 0,
+              parking.longitude ?? 0,
+              coords[0].latitude ?? 0,
+              coords[0].longitude ?? 0,
+            );
+          const distanceFromParkingToLastPoint =
+            calculateDistanceBetweenCoordinates(
+              parking.latitude ?? 0,
+              parking.longitude ?? 0,
+              coords[coords.length - 1].latitude ?? 0,
+              coords[coords.length - 1].longitude ?? 0,
+            );
+          if (
+            distanceFromParkingToLastPoint < distanceFromParkingToFirstPoint
+          ) {
+            coords.reverse();
+          }
+        }
+        onChange(coords);
+      };
+      reader.readAsText(file);
     },
     [onChange, parking],
   );
@@ -78,94 +102,95 @@ export const PolylineEditor = ({
       "application/gpx+xml": [".gpx"],
       "application/tcx+xml": [".tcx"],
     },
-    onDrop,
+    onDrop: onDrop as DropzoneOptions["onDrop"],
   });
+
+  const panes = [
+    {
+      menuItem: "Points",
+      render: () => (
+        <Tab.Pane>
+          {coordinates?.map((c, i) => {
+            const [backgroundColor, color] = colorLatLng(c);
+            return (
+              <Label
+                key={c.latitude + "," + c.longitude}
+                style={{
+                  backgroundColor,
+                  borderColor: backgroundColor,
+                  color,
+                }}
+              >
+                Point #{i}
+                <Icon
+                  name="delete"
+                  onClick={() => {
+                    coordinates.splice(i, 1);
+                    onChange(coordinates);
+                  }}
+                />
+              </Label>
+            );
+          })}
+        </Tab.Pane>
+      ),
+    },
+    {
+      menuItem: "Data",
+      render: () => (
+        <Tab.Pane>
+          <Input
+            placeholder="Outline"
+            value={
+              coordinates
+                ?.map((c) => c.latitude + "," + c.longitude)
+                .join(";") || ""
+            }
+            onChange={(_, { value }) => onChange(parsePolyline(value))}
+          />
+        </Tab.Pane>
+      ),
+    },
+  ];
+
+  if (upload) {
+    panes.push({
+      menuItem: "GPX/TCX",
+      render: () => (
+        <div {...getRootProps()} style={{ textAlign: "center" }}>
+          <Message>
+            <Message.Content>
+              Drag-and-drop a <code>.gpx</code>/<code>.tcx</code> file to create
+              the approach path. These can be obtained from GPS watches or from{" "}
+              <a
+                href="https://support.strava.com/hc/en-us/articles/216918437-Exporting-your-Data-and-Bulk-Export"
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                Strava
+              </a>{" "}
+              and{" "}
+              <a
+                href="https://help.fitbit.com/articles/en_US/Help_article/1133.htm"
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                Fitbit
+              </a>
+              .
+              <br />
+              <br />
+              <Button primary>Upload</Button>
+            </Message.Content>
+          </Message>
+        </div>
+      ),
+    });
+  }
 
   return (
     <Form.Field>
-      <Tab
-        panes={[
-          {
-            menuItem: "Points",
-            render: () => (
-              <Tab.Pane>
-                {coordinates?.map((c, i) => {
-                  const [backgroundColor, color] = colorLatLng(c);
-                  return (
-                    <Label
-                      key={c.latitude + "," + c.longitude}
-                      style={{
-                        backgroundColor,
-                        borderColor: backgroundColor,
-                        color,
-                      }}
-                    >
-                      Point #{i}
-                      <Icon
-                        name="delete"
-                        onClick={() => {
-                          coordinates.splice(i, 1);
-                          onChange(coordinates);
-                        }}
-                      />
-                    </Label>
-                  );
-                })}
-              </Tab.Pane>
-            ),
-          },
-          {
-            menuItem: "Data",
-            render: () => (
-              <Tab.Pane>
-                <Input
-                  placeholder="Outline"
-                  value={
-                    coordinates
-                      ?.map((c) => c.latitude + "," + c.longitude)
-                      .join(";") || ""
-                  }
-                  onChange={(_, { value }) => onChange(parsePolyline(value))}
-                />
-              </Tab.Pane>
-            ),
-          },
-
-          upload && {
-            menuItem: "GPX/TCX",
-            render: () => (
-              <div {...getRootProps()} style={{ textAlign: "center" }}>
-                <Message>
-                  <Message.Content>
-                    Drag-and-drop a <code>.gpx</code>/<code>.tcx</code> file to
-                    create the approach path. These can be obtained from GPS
-                    watches or from{" "}
-                    <a
-                      href="https://support.strava.com/hc/en-us/articles/216918437-Exporting-your-Data-and-Bulk-Export"
-                      rel="noreferrer noopener"
-                      target="_blank"
-                    >
-                      Strava
-                    </a>{" "}
-                    and{" "}
-                    <a
-                      href="https://help.fitbit.com/articles/en_US/Help_article/1133.htm"
-                      rel="noreferrer noopener"
-                      target="_blank"
-                    >
-                      Fitbit
-                    </a>
-                    .
-                    <br />
-                    <br />
-                    <Button primary>Upload</Button>
-                  </Message.Content>
-                </Message>
-              </div>
-            ),
-          },
-        ].filter(Boolean)}
-      />
+      <Tab panes={panes} />
     </Form.Field>
   );
 };

--- a/src/components/SectorEdit/PolylineMarkers.tsx
+++ b/src/components/SectorEdit/PolylineMarkers.tsx
@@ -1,12 +1,15 @@
 import { CircleMarker } from "react-leaflet";
 import { colorLatLng } from "../../utils/polyline";
 import { components } from "../../@types/buldreinfo/swagger";
+import { useMeta } from "../common/meta";
 
 type Props = {
   coordinates: components["schemas"]["Coordinates"][];
 };
 
 export const PolylineMarkers = ({ coordinates }: Props) => {
+  const { defaultCenter } = useMeta();
+
   if (!coordinates) {
     return null;
   }
@@ -15,7 +18,10 @@ export const PolylineMarkers = ({ coordinates }: Props) => {
     <CircleMarker
       key={c.latitude + "," + c.longitude}
       radius={5}
-      center={[c.latitude, c.longitude]}
+      center={[
+        c.latitude ?? defaultCenter.lat,
+        c.longitude ?? defaultCenter.lng,
+      ]}
       color={colorLatLng(c)[0]}
     />
   ));

--- a/src/components/SectorEdit/ProblemOrder.tsx
+++ b/src/components/SectorEdit/ProblemOrder.tsx
@@ -8,45 +8,54 @@ type Props = Pick<components["schemas"]["Sector"], "problemOrder"> & {
   ) => void;
 };
 
+/**
+ * This is just to work around the fact that _technically_ a Problem doesn't
+ * "need" to have an {@code id} field, since it's defined as optional in the
+ * Swagger-generated APIs. But we know that it'll be there and we can skip this.
+ */
+const TYPE_IMPOSSIBILITY = 0;
+
 export const ProblemOrder = ({ problemOrder, onChange }: Props) => {
-  const originalOrder = useRef(
+  const originalOrder: Record<number, number> = useRef(
     (problemOrder ?? []).reduce(
-      (acc, { id, nr }) => ({ ...acc, [id]: nr }),
+      (acc, { id, nr }) => ({ ...acc, [id ?? TYPE_IMPOSSIBILITY]: nr }),
       {},
     ),
   ).current;
 
-  return problemOrder.map(({ id, name, nr }) => {
-    const isModified = nr !== originalOrder[id];
-    const color = isModified ? "orange" : "grey";
-    return (
-      <Input
-        key={id}
-        size="small"
-        type="number"
-        step={1}
-        fluid
-        icon="hashtag"
-        iconPosition="left"
-        placeholder="Number"
-        defaultValue={nr}
-        label={{ basic: true, content: name, color }}
-        labelPosition="right"
-        onChange={(_, { value }) => {
-          const num = +value;
-          onChange(
-            problemOrder.map((problem) => {
-              if (problem.id === id) {
-                return {
-                  ...problem,
-                  nr: num,
-                };
-              }
-              return problem;
-            }),
-          );
-        }}
-      />
-    );
-  });
+  return (
+    problemOrder?.map(({ id, name, nr }) => {
+      const isModified = nr !== originalOrder[id ?? TYPE_IMPOSSIBILITY];
+      const color = isModified ? "orange" : "grey";
+      return (
+        <Input
+          key={id}
+          size="small"
+          type="number"
+          step={1}
+          fluid
+          icon="hashtag"
+          iconPosition="left"
+          placeholder="Number"
+          defaultValue={nr}
+          label={{ basic: true, content: name, color }}
+          labelPosition="right"
+          onChange={(_, { value }) => {
+            const num = +value;
+            onChange(
+              problemOrder.map((problem) => {
+                if (problem.id === id) {
+                  return {
+                    ...problem,
+                    nr: num,
+                  };
+                }
+                return problem;
+              }),
+            );
+          }}
+        />
+      );
+    }) ?? []
+  );
 };

--- a/src/components/SectorEdit/ZoomLogic.tsx
+++ b/src/components/SectorEdit/ZoomLogic.tsx
@@ -2,6 +2,7 @@ import { latLngBounds } from "leaflet";
 import { useRef, useEffect } from "react";
 import { useMap } from "react-leaflet";
 import { components } from "../../@types/buldreinfo/swagger";
+import { useMeta } from "../common/meta";
 
 type Props = {
   area: components["schemas"]["Area"];
@@ -12,6 +13,7 @@ export const ZoomLogic = ({
   area: loadedArea,
   sector: loadedSector,
 }: Props) => {
+  const { defaultCenter } = useMeta();
   const map = useMap();
   const sectorRef = useRef(loadedSector);
   const areaRef = useRef(loadedArea);
@@ -19,29 +21,35 @@ export const ZoomLogic = ({
   useEffect(() => {
     const bounds = latLngBounds([]);
     if (sectorRef.current) {
-      if (sectorRef.current.outline?.length > 0) {
+      if (sectorRef.current.outline?.length) {
         for (const coordinates of sectorRef.current.outline) {
-          bounds.extend([coordinates.latitude, coordinates.longitude]);
+          bounds.extend([
+            coordinates.latitude ?? defaultCenter.lat,
+            coordinates.longitude ?? defaultCenter.lng,
+          ]);
         }
       }
 
-      if (sectorRef.current.approach?.coordinates?.length > 0) {
+      if (sectorRef.current.approach?.coordinates?.length) {
         for (const coordinates of sectorRef.current.approach.coordinates) {
-          bounds.extend([coordinates.latitude, coordinates.longitude]);
+          bounds.extend([
+            coordinates.latitude ?? defaultCenter.lat,
+            coordinates.longitude ?? defaultCenter.lng,
+          ]);
         }
       }
 
       if (sectorRef.current.parking) {
         bounds.extend([
-          sectorRef.current.parking.latitude,
-          sectorRef.current.parking.longitude,
+          sectorRef.current.parking.latitude ?? defaultCenter.lat,
+          sectorRef.current.parking.longitude ?? defaultCenter.lng,
         ]);
       }
     } else if (areaRef.current) {
       if (areaRef.current.coordinates) {
         bounds.extend([
-          areaRef.current.coordinates.latitude,
-          areaRef.current.coordinates.longitude,
+          areaRef.current.coordinates.latitude ?? defaultCenter.lat,
+          areaRef.current.coordinates.longitude ?? defaultCenter.lng,
         ]);
       }
     }
@@ -49,7 +57,7 @@ export const ZoomLogic = ({
     if (bounds.isValid()) {
       map.fitBounds(bounds);
     }
-  }, [map]);
+  }, [defaultCenter.lat, defaultCenter.lng, map]);
 
   return null;
 };

--- a/src/components/SectorEdit/index.ts
+++ b/src/components/SectorEdit/index.ts
@@ -1,1 +1,1 @@
-export { SectorEdit as default } from "./SectorEdit";
+export { SectorEditLoader as default } from "./SectorEdit";


### PR DESCRIPTION
Focusing on `SectorEdit`, set `strict: true` in `tsconfig.json` and fix the detected errors.

This shouldn't cause any changes to user-visible behavior (none were noticed in my local testing, though I can't promose it was 100% thorough). However, there are some under-the-hood improvements with Sentry reporting various "WTF?"-type situations, if they should occur.