### PR TITLE
feat: Add a navigation popup to parking markers

### DIFF
--- a/src/components/Problem/Problem.tsx
+++ b/src/components/Problem/Problem.tsx
@@ -128,7 +128,6 @@ export const Problem = () => {
   if (data.sectorParking) {
     markers.push({
       coordinates: data.sectorParking,
-      url: "/sector/" + data.sectorId,
       isParking: true,
     });
   }

--- a/src/components/common/leaflet/leaflet.tsx
+++ b/src/components/common/leaflet/leaflet.tsx
@@ -167,7 +167,7 @@ const Leaflet = ({
                 .map((m: MarkerDef & { url: string }) => (
                   <React.Fragment key={m.url}>
                     <a rel="noreferrer noopener" target="_blank" href={m.url}>
-                      {m.label}
+                      {"label" in m ? m.label : ""}
                     </a>
                     <br />
                   </React.Fragment>


### PR DESCRIPTION
The current parking markers are buggy, and not terribly helpful.

 - When looking at an area, the "parking marker" is actually a bunch of markers all stacked up on top of each other - one for each sector. Clicking on it will navigate you to a pseudo-random sector, which isn't what I want.

 - When looking at a sector, the parking marker doesn't actually do anything.

 - When looking at a problem, the parking marker will navigate you to that same problem. Again, not helpful.

Instead, this change replaces all navigation with a popup. This popup contains a button to open Google Maps pointed to that location. The intention of this feature is to allow mobile users to get driving directions/estimates to the parking area (desktop users too, but that's possibly less-important).