### PR TITLE
feat: Make the area page stateful

### DIFF
--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -124,6 +124,7 @@ function AppRoutes() {
           <Route path="/" element={<Frontpage />} />
           <Route path="/about" element={<About />} />
           <Route path="/area/:areaId" element={<Area />} />
+          <Route path="/area/:areaId/:pane" element={<Area />} />
           <Route
             path="/area/edit/:areaId"
             element={


### PR DESCRIPTION
Make the `/area/:areaId` page more stateful by putting the current nested tab in the URL. This change also combines the two separate nested tab panes.