### PR TITLE
fix: Enable clicking on sectors on the map to navigate

### DIFF
--- a/src/components/common/TableOfContents/ProblemsMap/ProblemsMap.tsx
+++ b/src/components/common/TableOfContents/ProblemsMap/ProblemsMap.tsx
@@ -187,7 +187,7 @@ const SectorOutlines = ({ areas }: Props) => {
         ...rest,
         label: zoom > 12 ? label : undefined,
       }))}
-      addEventHandlers={false}
+      addEventHandlers={true}
     />
   );
 };


### PR DESCRIPTION
For some reason, this boolean is set to false, making it hard to use the map to navigate to specific problems. Is there a reason why this is disabled?