### PR TITLE
Updated ReactPlayer to fix video player loop bug and improved skipping. Also updated video size.

### DIFF
--- a/src/components/common/media/media-modal.tsx
+++ b/src/components/common/media/media-modal.tsx
@@ -135,7 +135,6 @@ const MediaModal = ({
       .filter((value, index, self) => self.indexOf(value) === index).length > 1;
   const [prevHover, setPrevHover] = useState(false);
   const [nextHover, setNextHover] = useState(false);
-  const playerRef = useRef<any>(null);
   const isImage = m?.idType === 1;
 
   const content = (() => {
@@ -194,7 +193,6 @@ const MediaModal = ({
       return (
         <ReactPlayer
           style={style.video}
-          ref={playerRef}
           src={getBuldreinfoMediaUrlSupported(m.id)}
           controls={true}
           playing={true}
@@ -718,4 +716,4 @@ const MediaModal = ({
   );
 };
 
-export default MediaModal
+export default MediaModal;

--- a/src/components/common/media/media-modal.tsx
+++ b/src/components/common/media/media-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { components } from "../../../@types/buldreinfo/swagger";
 import { useLocalStorage } from "../../../utils/use-local-storage";
 import {
@@ -135,7 +135,16 @@ const MediaModal = ({
       .filter((value, index, self) => self.indexOf(value) === index).length > 1;
   const [prevHover, setPrevHover] = useState(false);
   const [nextHover, setNextHover] = useState(false);
+  const [hasSetVideoTimestamp, setHasSetVideoTimestamp] = useState(false);
+  const [videoVolume, setVideoVolume] = useState(1);
+  const [isPlaying, setIsPlaying] = useState(true);
+  const playerRef = useRef<HTMLVideoElement | null>(null);
   const isImage = m?.idType === 1;
+
+  useEffect(() => {
+    setHasSetVideoTimestamp(false);
+    setIsPlaying(true);
+  }, [m.id]);
 
   const content = (() => {
     if (isImage) {
@@ -192,10 +201,32 @@ const MediaModal = ({
     if (autoPlayVideo) {
       return (
         <ReactPlayer
+          ref={playerRef}
           style={style.video}
           src={getBuldreinfoMediaUrlSupported(m.id)}
           controls={true}
-          playing={true}
+          playing={isPlaying}
+          volume={videoVolume}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onVolumeChange={() => {
+            if (playerRef.current) {
+              setVideoVolume(playerRef.current.volume);
+            }
+          }}
+          onProgress={() => {
+            const seconds = parseInt(m.t);
+            if (
+              !hasSetVideoTimestamp &&
+              !Number.isNaN(seconds) &&
+              Number.isFinite(seconds) &&
+              playerRef.current &&
+              seconds < playerRef.current.duration
+            ) {
+              playerRef.current.currentTime = seconds;
+              setHasSetVideoTimestamp(true);
+            }
+          }}
         />
       );
     }

--- a/src/components/common/media/media-modal.tsx
+++ b/src/components/common/media/media-modal.tsx
@@ -35,6 +35,8 @@ const style = {
     objectFit: "scale-down",
   },
   video: {
+    width: "100vw",
+    height: "80vh",
     maxHeight: "100vh",
     maxWidth: "100vw",
   },
@@ -133,7 +135,7 @@ const MediaModal = ({
       .filter((value, index, self) => self.indexOf(value) === index).length > 1;
   const [prevHover, setPrevHover] = useState(false);
   const [nextHover, setNextHover] = useState(false);
-  const playerRef = useRef<HTMLVideoElement | null>(null);
+  const playerRef = useRef<any>(null);
   const isImage = m?.idType === 1;
 
   const content = (() => {
@@ -196,17 +198,6 @@ const MediaModal = ({
           src={getBuldreinfoMediaUrlSupported(m.id)}
           controls={true}
           playing={true}
-          onProgress={() => {
-            const seconds = parseInt(m.t);
-            if (
-              !Number.isNaN(seconds) &&
-              Number.isFinite(seconds) &&
-              playerRef.current &&
-              seconds < playerRef.current.duration
-            ) {
-              playerRef.current.currentTime = seconds;
-            }
-          }}
         />
       );
     }
@@ -727,4 +718,4 @@ const MediaModal = ({
   );
 };
 
-export default MediaModal;
+export default MediaModal


### PR DESCRIPTION
There seems to be an issue with the current onProgress as it caused the video player to loop back to the beginning each time it reached the buffer. Also skipping within the video has not really worked that great on the site before the video was fully loaded. They both seem to be fixed within my localhost testing.