### PR TITLE
Remember route filters when navigating between pages.

### DIFF
--- a/src/features/Area/Area.tsx
+++ b/src/features/Area/Area.tsx
@@ -1092,6 +1092,7 @@ const Area = () => {
                 storageKey={`area/${areaId}`}
                 mode='sector'
                 sortPreferenceBucket='area'
+                filterPreferenceBucket='sector'
                 defaultOrder='grade-desc'
                 rows={problemRows}
                 enableViewModeToggle

--- a/src/features/Sector/Sector.tsx
+++ b/src/features/Sector/Sector.tsx
@@ -1043,6 +1043,7 @@ const Sector = () => {
             storageKey={`sector/${sectorId}`}
             mode='sector'
             sortPreferenceBucket={data.orderByGrade ? 'grade' : 'number'}
+            filterPreferenceBucket='sector'
             defaultOrder={data.orderByGrade ? 'grade-desc' : 'number'}
             rows={sectorProblemListRows}
             enableViewModeToggle

--- a/src/shared/components/ProblemList/ProblemList.tsx
+++ b/src/shared/components/ProblemList/ProblemList.tsx
@@ -522,11 +522,7 @@ export const ProblemList = ({
   const showListControls = allRows.length >= MIN_ROWS_FOR_LIST_CONTROLS;
 
   const hasActiveFilters =
-    gradeLow !== undefined ||
-    gradeHigh !== undefined ||
-    Object.values(types).some((v) => !v) ||
-    hideTicked ||
-    onlyFa;
+    gradeLow !== undefined || gradeHigh !== undefined || Object.values(types).some((v) => !v) || hideTicked || onlyFa;
 
   if (!allRows?.length) {
     return null;
@@ -635,16 +631,15 @@ export const ProblemList = ({
               )}
             >
               {hasActiveFilters && !showFilter && (
-                <span
-                  className='absolute -top-1 -right-1 h-2 w-2 rounded-full bg-brand'
-                  aria-hidden='true'
-                />
+                <span className='bg-brand absolute -top-1 -right-1 h-2 w-2 rounded-full' aria-hidden='true' />
               )}
               <Filter
                 size={12}
                 className={cn(
                   'shrink-0',
-                  showFilter || hasActiveFilters ? cn('text-brand', twInk.lightTextSlate900) : problemListToolbarChipInk,
+                  showFilter || hasActiveFilters
+                    ? cn('text-brand', twInk.lightTextSlate900)
+                    : problemListToolbarChipInk,
                 )}
                 strokeWidth={2}
               />
@@ -652,7 +647,9 @@ export const ProblemList = ({
                 className={cn(
                   designContract.typography.uiCompact,
                   'whitespace-nowrap',
-                  showFilter || hasActiveFilters ? cn('text-brand', twInk.lightTextSlate900) : problemListToolbarChipInk,
+                  showFilter || hasActiveFilters
+                    ? cn('text-brand', twInk.lightTextSlate900)
+                    : problemListToolbarChipInk,
                 )}
               >
                 Filter

--- a/src/shared/components/ProblemList/ProblemList.tsx
+++ b/src/shared/components/ProblemList/ProblemList.tsx
@@ -19,6 +19,8 @@ type Props = {
   storageKey: string;
   /** Sector/area: remember sort in localStorage (shared by grade vs number listing style). User lists omit. */
   sortPreferenceBucket?: 'grade' | 'number' | 'area';
+  /** Sector/area: remember grade range + type filters in localStorage under a shared key. Use `'sector'` for sector/area lists. Omit for user profile lists. */
+  filterPreferenceBucket?: string;
   toolbarAction?: React.ReactNode;
   /** Renders above the toolbar (e.g. map) so group/sort/filter stay between map and list. */
   contentBeforeList?: React.ReactNode | ((filteredRows: Row[]) => React.ReactNode);
@@ -445,6 +447,7 @@ export const ProblemList = ({
   defaultOrder,
   storageKey,
   sortPreferenceBucket,
+  filterPreferenceBucket,
   toolbarAction,
   contentBeforeList,
   excludedSortOptions,
@@ -503,6 +506,7 @@ export const ProblemList = ({
     order: defaultOrder,
     key: storageKey,
     sortPreferenceBucket,
+    filterPreferenceBucket,
   });
 
   const orderByOptions = ORDER_BY_OPTIONS[mode].filter((opt) => !excludedSortOptions?.includes(opt.value));
@@ -516,6 +520,15 @@ export const ProblemList = ({
     .filter((label) => (mapping[label] ?? maxGradeIndex) > (mapping[currentLow] ?? 0))
     .map((label) => ({ key: `high-${label}`, text: label, shortText: label, value: label }));
   const showListControls = allRows.length >= MIN_ROWS_FOR_LIST_CONTROLS;
+
+  // True when any filter is narrowing the list — used to keep the button highlighted even
+  // when the filter panel is closed (e.g. on first load after persisted filters are restored).
+  const hasActiveFilters =
+    gradeLow !== undefined ||
+    gradeHigh !== undefined ||
+    Object.values(types).some((v) => !v) ||
+    hideTicked ||
+    onlyFa;
 
   if (!allRows?.length) {
     return null;
@@ -614,20 +627,26 @@ export const ProblemList = ({
               onClick={() => setFilterShowing((v) => !v)}
               className={cn(
                 activityFilterChipBase,
-                showFilter
+                showFilter || hasActiveFilters
                   ? cn(
                       'border-brand-border bg-brand/22 text-brand shadow-sm',
                       'light:border-brand light:bg-brand/28 light:shadow-sm',
                     )
                   : activityFilterChipOn,
-                'shrink-0 justify-center transition-[background-color,border-color,color,box-shadow]',
+                'relative shrink-0 justify-center transition-[background-color,border-color,color,box-shadow]',
               )}
             >
+              {hasActiveFilters && !showFilter && (
+                <span
+                  className='absolute -top-1 -right-1 h-2 w-2 rounded-full bg-brand'
+                  aria-hidden='true'
+                />
+              )}
               <Filter
                 size={12}
                 className={cn(
                   'shrink-0',
-                  showFilter ? cn('text-brand', twInk.lightTextSlate900) : problemListToolbarChipInk,
+                  showFilter || hasActiveFilters ? cn('text-brand', twInk.lightTextSlate900) : problemListToolbarChipInk,
                 )}
                 strokeWidth={2}
               />
@@ -635,7 +654,7 @@ export const ProblemList = ({
                 className={cn(
                   designContract.typography.uiCompact,
                   'whitespace-nowrap',
-                  showFilter ? cn('text-brand', twInk.lightTextSlate900) : problemListToolbarChipInk,
+                  showFilter || hasActiveFilters ? cn('text-brand', twInk.lightTextSlate900) : problemListToolbarChipInk,
                 )}
               >
                 Filter

--- a/src/shared/components/ProblemList/ProblemList.tsx
+++ b/src/shared/components/ProblemList/ProblemList.tsx
@@ -521,8 +521,6 @@ export const ProblemList = ({
     .map((label) => ({ key: `high-${label}`, text: label, shortText: label, value: label }));
   const showListControls = allRows.length >= MIN_ROWS_FOR_LIST_CONTROLS;
 
-  // True when any filter is narrowing the list — used to keep the button highlighted even
-  // when the filter panel is closed (e.g. on first load after persisted filters are restored).
   const hasActiveFilters =
     gradeLow !== undefined ||
     gradeHigh !== undefined ||

--- a/src/shared/components/ProblemList/state.ts
+++ b/src/shared/components/ProblemList/state.ts
@@ -174,6 +174,7 @@ export const useProblemListState = ({
   order: defaultOrder,
   key,
   sortPreferenceBucket,
+  filterPreferenceBucket,
 }: {
   rows: Row[];
   order: State['order'];
@@ -183,6 +184,12 @@ export const useProblemListState = ({
    * plus area aggregate). Omit for user profile lists — then sort is keyed by `problemList/${key}/order`.
    */
   sortPreferenceBucket?: 'grade' | 'number' | 'area';
+  /**
+   * When provided, grade range and type filters are persisted in localStorage under a shared key so
+   * they carry over when navigating between pages in the same context (e.g. sector browsing).
+   * Use `'sector'` for sector and area lists. Omit for user profile lists (per-page key used instead).
+   */
+  filterPreferenceBucket?: string;
 }): State & { dispatch: Dispatch<Update> } => {
   const [storedHideTicked, setStoredHideTicked] = useSessionStorage(`problemList/${key}/hideTicked`, false);
   const [storedOnlyFa, setStoredOnlyFa] = useSessionStorage(`problemList/${key}/onlyFa`, false);
@@ -194,22 +201,55 @@ export const useProblemListState = ({
 
   const [storedOrderBy, setStoredOrderBy] = useLocalStorage(orderStorageKey, defaultOrder);
 
+  // Grade / type filters: shared across pages when a bucket is given, otherwise isolated per page.
+  // Note: gradeLow/gradeHigh are stored as string|null because JSON.stringify(undefined) is lossy.
+  const filterStorageKey =
+    filterPreferenceBucket != null
+      ? `problemList/filterPreference/${filterPreferenceBucket}`
+      : `problemList/${key}`;
+  const [storedGradeLow, setStoredGradeLow] = useLocalStorage<string | null>(`${filterStorageKey}/gradeLow`, null);
+  const [storedGradeHigh, setStoredGradeHigh] = useLocalStorage<string | null>(
+    `${filterStorageKey}/gradeHigh`,
+    null,
+  );
+  const [storedTypes, setStoredTypes] = useLocalStorage<Record<string, boolean>>(
+    `${filterStorageKey}/types`,
+    {},
+  );
+
   const { mapping, easyToHard, idToGrade } = useGrades();
   const typeNames = useMemo(() => [...new Set(rows.map(rowListTypeKey))].sort(), [rows]);
+
+  // Validate stored grade labels: if the grade system has changed since the value was stored
+  // (e.g. after a deploy or on a different locale), the label may be absent from `mapping`.
+  // An unknown label produces undefined index values, causing every row to fail the filter.
+  // Treat unknown labels as null (= no filter) rather than passing them through.
+  const validGradeLow = storedGradeLow !== null && easyToHard.includes(storedGradeLow) ? storedGradeLow : null;
+  const validGradeHigh = storedGradeHigh !== null && easyToHard.includes(storedGradeHigh) ? storedGradeHigh : null;
+
   const [{ gradeLow, gradeHigh, hideTicked, onlyFa, order, groupBy, types }, dispatch] = useReducer(uiStateReducer, {
-    gradeHigh: undefined,
-    gradeLow: undefined,
+    gradeLow: validGradeLow ?? undefined,
+    gradeHigh: validGradeHigh ?? undefined,
     order: CLEANED_ORDER[storedOrderBy as OrderOption] ?? defaultOrder,
     /** Grouping is not persisted — default to none each visit. */
     groupBy: 'none',
     hideTicked: storedHideTicked,
     onlyFa: storedOnlyFa,
-    types: rows.reduce((acc, row) => ({ ...acc, [rowListTypeKey(row)]: true }), {} as Record<string, boolean>),
+    types: rows.reduce((acc, row) => {
+      const tKey = rowListTypeKey(row);
+      return { ...acc, [tKey]: storedTypes[tKey] ?? true };
+    }, {} as Record<string, boolean>),
   });
 
   useEffect(() => setStoredHideTicked(hideTicked), [hideTicked, setStoredHideTicked]);
   useEffect(() => setStoredOnlyFa(onlyFa), [onlyFa, setStoredOnlyFa]);
   useEffect(() => setStoredOrderBy(order), [order, setStoredOrderBy]);
+  useEffect(() => setStoredGradeLow(gradeLow ?? null), [gradeLow, setStoredGradeLow]);
+  useEffect(() => setStoredGradeHigh(gradeHigh ?? null), [gradeHigh, setStoredGradeHigh]);
+  // Merge into the existing stored object rather than replacing it wholesale.
+  // This preserves type preferences from other sectors (which may have different type sets)
+  // that would otherwise be clobbered on every mount.
+  useEffect(() => setStoredTypes((prev) => ({ ...prev, ...types })), [types, setStoredTypes]);
   useEffect(() => dispatch({ action: 'init-types', typeNames }), [typeNames]);
 
   const [filtered, uniqueAreas, uniqueRocks, uniqueSectors, uniqueTypes] = useMemo(() => {

--- a/src/shared/components/ProblemList/state.ts
+++ b/src/shared/components/ProblemList/state.ts
@@ -201,8 +201,6 @@ export const useProblemListState = ({
 
   const [storedOrderBy, setStoredOrderBy] = useLocalStorage(orderStorageKey, defaultOrder);
 
-  // Grade / type filters: shared across pages when a bucket is given, otherwise isolated per page.
-  // Note: gradeLow/gradeHigh are stored as string|null because JSON.stringify(undefined) is lossy.
   const filterStorageKey =
     filterPreferenceBucket != null
       ? `problemList/filterPreference/${filterPreferenceBucket}`
@@ -220,10 +218,6 @@ export const useProblemListState = ({
   const { mapping, easyToHard, idToGrade } = useGrades();
   const typeNames = useMemo(() => [...new Set(rows.map(rowListTypeKey))].sort(), [rows]);
 
-  // Validate stored grade labels: if the grade system has changed since the value was stored
-  // (e.g. after a deploy or on a different locale), the label may be absent from `mapping`.
-  // An unknown label produces undefined index values, causing every row to fail the filter.
-  // Treat unknown labels as null (= no filter) rather than passing them through.
   const validGradeLow = storedGradeLow !== null && easyToHard.includes(storedGradeLow) ? storedGradeLow : null;
   const validGradeHigh = storedGradeHigh !== null && easyToHard.includes(storedGradeHigh) ? storedGradeHigh : null;
 
@@ -246,9 +240,6 @@ export const useProblemListState = ({
   useEffect(() => setStoredOrderBy(order), [order, setStoredOrderBy]);
   useEffect(() => setStoredGradeLow(gradeLow ?? null), [gradeLow, setStoredGradeLow]);
   useEffect(() => setStoredGradeHigh(gradeHigh ?? null), [gradeHigh, setStoredGradeHigh]);
-  // Merge into the existing stored object rather than replacing it wholesale.
-  // This preserves type preferences from other sectors (which may have different type sets)
-  // that would otherwise be clobbered on every mount.
   useEffect(() => setStoredTypes((prev) => ({ ...prev, ...types })), [types, setStoredTypes]);
   useEffect(() => dispatch({ action: 'init-types', typeNames }), [typeNames]);
 

--- a/src/shared/components/ProblemList/state.ts
+++ b/src/shared/components/ProblemList/state.ts
@@ -202,18 +202,10 @@ export const useProblemListState = ({
   const [storedOrderBy, setStoredOrderBy] = useLocalStorage(orderStorageKey, defaultOrder);
 
   const filterStorageKey =
-    filterPreferenceBucket != null
-      ? `problemList/filterPreference/${filterPreferenceBucket}`
-      : `problemList/${key}`;
+    filterPreferenceBucket != null ? `problemList/filterPreference/${filterPreferenceBucket}` : `problemList/${key}`;
   const [storedGradeLow, setStoredGradeLow] = useLocalStorage<string | null>(`${filterStorageKey}/gradeLow`, null);
-  const [storedGradeHigh, setStoredGradeHigh] = useLocalStorage<string | null>(
-    `${filterStorageKey}/gradeHigh`,
-    null,
-  );
-  const [storedTypes, setStoredTypes] = useLocalStorage<Record<string, boolean>>(
-    `${filterStorageKey}/types`,
-    {},
-  );
+  const [storedGradeHigh, setStoredGradeHigh] = useLocalStorage<string | null>(`${filterStorageKey}/gradeHigh`, null);
+  const [storedTypes, setStoredTypes] = useLocalStorage<Record<string, boolean>>(`${filterStorageKey}/types`, {});
 
   const { mapping, easyToHard, idToGrade } = useGrades();
   const typeNames = useMemo(() => [...new Set(rows.map(rowListTypeKey))].sort(), [rows]);
@@ -229,10 +221,13 @@ export const useProblemListState = ({
     groupBy: 'none',
     hideTicked: storedHideTicked,
     onlyFa: storedOnlyFa,
-    types: rows.reduce((acc, row) => {
-      const tKey = rowListTypeKey(row);
-      return { ...acc, [tKey]: storedTypes[tKey] ?? true };
-    }, {} as Record<string, boolean>),
+    types: rows.reduce(
+      (acc, row) => {
+        const tKey = rowListTypeKey(row);
+        return { ...acc, [tKey]: storedTypes[tKey] ?? true };
+      },
+      {} as Record<string, boolean>,
+    ),
   });
 
   useEffect(() => setStoredHideTicked(hideTicked), [hideTicked, setStoredHideTicked]);

--- a/src/utils/use-local-storage.tsx
+++ b/src/utils/use-local-storage.tsx
@@ -35,14 +35,16 @@ function useStorage<T = unknown>(system: typeof window.localStorage, key: string
   const setValue = useCallback(
     (value: Parameters<typeof setStoredValue>[0]) => {
       try {
-        const valueToStore = value instanceof Function ? value(storedValue) : value;
-        setStoredValue(value);
-        system.setItem(key, JSON.stringify(valueToStore));
+        setStoredValue((prev) => {
+          const valueToStore = value instanceof Function ? value(prev) : value;
+          system.setItem(key, JSON.stringify(valueToStore));
+          return valueToStore;
+        });
       } catch (error) {
         console.warn('localStorage setValue error:', error);
       }
     },
-    [key, storedValue, system],
+    [key, system],
   );
 
   const writeValue = useCallback(


### PR DESCRIPTION
This pull request adds filters to localStorage so it's remembered both when navigating between pages and when coming back to the page at a later date.

Right now, if you want to filter away trad routes etc you have to set the filter each time the area and sector page loads.